### PR TITLE
Redesign: Klaviyo Ascent system + interactive layer (⌘K, dark mode, live GitHub panel)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ dist-ssr
 .vscode/*
 !.vscode/extensions.json
 .idea
+.claude/
 .DS_Store
 *.suo
 *.ntvs*

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -2,12 +2,45 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Langlois Portfolio</title>
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Caveat&display=swap" rel="stylesheet">
+    <title>Jake Langlois — Software Engineer</title>
+    <meta
+      name="description"
+      content="Jake Langlois — software engineer studying CS + Math at Northeastern. Currently building at Klaviyo."
+    />
+    <meta name="theme-color" content="#f9fafb" />
+
+    <!-- Apply saved/system theme before paint to avoid a flash -->
+    <script>
+      ;(function () {
+        try {
+          var t = localStorage.getItem('theme')
+          if (!t)
+            t = window.matchMedia('(prefers-color-scheme: dark)').matches
+              ? 'dark'
+              : 'light'
+          if (t === 'dark') document.documentElement.classList.add('dark')
+        } catch (e) {}
+      })()
+    </script>
+
+    <!-- Open Graph -->
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="https://jakelanglois.com" />
+    <meta property="og:title" content="Jake Langlois — Software Engineer" />
+    <meta
+      property="og:description"
+      content="CS + Math @ Northeastern. Currently building at Klaviyo."
+    />
+    <meta name="twitter:card" content="summary" />
+
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
   </head>
   <body>
     <div id="root"></div>

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,14 +9,12 @@
       "version": "0.0.0",
       "dependencies": {
         "autoprefixer": "^10.4.16",
-        "axios": "^1.6.0",
+        "cmdk": "^1.1.1",
         "postcss-nesting": "^12.0.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-icons": "^4.11.0",
         "react-router-dom": "^6.20.0",
-        "react-scroll": "^1.9.0",
-        "react-vertical-timeline-component": "^3.6.0",
         "tailwindcss": "^3.3.5",
         "typed.js": "^2.1.0"
       },
@@ -64,6 +62,7 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.5.tgz",
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -390,6 +389,321 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@radix-ui/primitive": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.7.tgz",
+      "integrity": "sha512-rqWnm76nYT8HoNNqEjpgJ7Pw/DrBj5iBTrmEPo6HTX5+VJyBNOqTdv4g89G63HuR5g0AaENoAcH7Is5fF2kZ8Q==",
+      "license": "MIT"
+    },
+    "node_modules/@radix-ui/react-compose-refs": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.4.tgz",
+      "integrity": "sha512-pWJo6lQAfR6uy1n7ii7PaCc9dLPwTXDYbQpORZU5B548Aqvl2pP1SM1vJGKyxIFqZMHRopRO4CQYX2iXAIB5jA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-context": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.2.1.tgz",
+      "integrity": "sha512-EraVbFjiIjibpLr6EjvEDmSCYJU2SlKDMiO+qEK/D9GOWnQoAQlpQo2occGYC1UM9MBeEx5Bek3UtW/Qi57vAg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dialog": {
+      "version": "1.1.22",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dialog/-/react-dialog-1.1.22.tgz",
+      "integrity": "sha512-ZvXpCrhEH2OrVa1l8caiuWzrk6Qleq6PeZQ824lXxUxFu6mE4/XzRz1DliOvS18WuBl3A3clg2gHPNiPqz8BjA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.4",
+        "@radix-ui/react-context": "1.2.1",
+        "@radix-ui/react-dismissable-layer": "1.1.18",
+        "@radix-ui/react-focus-guards": "1.1.5",
+        "@radix-ui/react-focus-scope": "1.1.15",
+        "@radix-ui/react-id": "1.1.3",
+        "@radix-ui/react-portal": "1.1.16",
+        "@radix-ui/react-presence": "1.1.9",
+        "@radix-ui/react-primitive": "2.1.9",
+        "@radix-ui/react-slot": "1.3.2",
+        "@radix-ui/react-use-controllable-state": "1.2.5",
+        "@radix-ui/react-use-layout-effect": "1.1.3",
+        "aria-hidden": "^1.2.4",
+        "react-remove-scroll": "^2.7.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dismissable-layer": {
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.18.tgz",
+      "integrity": "sha512-4tuTRonWG1Etcbc597++jlROMx7r34Otb0fATJhaK16Uq7XRotUS1aGyDX+yOBh668HQzhcpUpTLXFqMRVuFeA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.4",
+        "@radix-ui/react-primitive": "2.1.9",
+        "@radix-ui/react-use-callback-ref": "1.1.3",
+        "@radix-ui/react-use-effect-event": "0.0.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-focus-guards": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-guards/-/react-focus-guards-1.1.5.tgz",
+      "integrity": "sha512-UQvlB7L/BYh3P8MLvwZnQkH521EDos40Rwnbt5+Qpg4Vbk0z3xJjRUmR6+aka4aT1IQQXFdO5bNPoE7cvFl5xQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-focus-scope": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-scope/-/react-focus-scope-1.1.15.tgz",
+      "integrity": "sha512-rKjyFmJRsUhrCg39GJ0DOMfrOxHbw8WaS/KMOUPhLLm80LfDffRQGzF8RdulfDP3QfOJPJj4Sma+EU3E/90ykw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.4",
+        "@radix-ui/react-primitive": "2.1.9",
+        "@radix-ui/react-use-callback-ref": "1.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-id": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-1.1.3.tgz",
+      "integrity": "sha512-f/Wxm0ctyMymUJK0fqTSQlm85rbzdAkoNbPXJQ5+6caowVO8Yx+NWGjGz/oGhs/D+WIbbQpOrU0hU2Li2/42xQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-portal": {
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-1.1.16.tgz",
+      "integrity": "sha512-Lml0Z1vVXni7Sk29TTltPF2+SYTUrTJONrlrfQMTDGNKzEkXHIdHqYDQ/TkHEqsKT9Igy2jDWP7AmFeDeimd2w==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.9",
+        "@radix-ui/react-use-layout-effect": "1.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-presence": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.9.tgz",
+      "integrity": "sha512-LTi1v05bprIb8/GSY/GWusI0jfsYjQ3CD3Nin8o7jVxnpHzVQfzjOQJoJTQkE9bdmOnsS7SFdhkXiBv8PrYnxw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.9.tgz",
+      "integrity": "sha512-aX5c84AYUD0EIodbQfpujB5XI0CbEaQ5U9du/wntNQK451i5iCJlE2JN6IN1LgQ3SnoBbnW/Jv1Z4rUowZV+hg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.3.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-slot": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.3.2.tgz",
+      "integrity": "sha512-nLBh0hpzgQA16ioKAWTSQvGjRj7QcI3pTpngtYZ12b4RP9N8eGSj7ziceHyHe04zrd0bAcLyMijO0ws0DLmDWw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-callback-ref": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.3.tgz",
+      "integrity": "sha512-AUS7HoBBAncIsGMLNG+CcpLuJ+JIBbZzmyM8Qdb1eIThX0AlhSSC6wn40xfBlPE+ypx/vSSiRWnklUAjy3U3UA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-controllable-state": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.2.5.tgz",
+      "integrity": "sha512-UB1dXpxvHjR48poyKdKdTm7jT0kp3elkUKdKQiOkirlbYumqXinSJtrjDsr9maXNPvL12bKI4CDSmydms/9Aeg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.7",
+        "@radix-ui/react-use-effect-event": "0.0.4",
+        "@radix-ui/react-use-layout-effect": "1.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-effect-event": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-effect-event/-/react-use-effect-event-0.0.4.tgz",
+      "integrity": "sha512-XYcfa6wlXDCwQtePuEiPmXLSAhGL4DWtedSyRgGbG3y10mw+OnrLp6SyeY1gJFMiYF0Dx0nMAX9InylKbLEFQQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-layout-effect": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.3.tgz",
+      "integrity": "sha512-rDiah9wvtqihWtWz02XreeRKIxt2EJF8y5D9rtY9l5A2zxePAtcPiOMpDugNRw5bFHz+1/8viVoc7ZVKiJknCw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@remix-run/router": {
       "version": "1.23.1",
       "license": "MIT",
@@ -441,13 +755,14 @@
     },
     "node_modules/@types/prop-types": {
       "version": "15.7.15",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@types/react": {
       "version": "18.3.27",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -455,8 +770,9 @@
     },
     "node_modules/@types/react-dom": {
       "version": "18.3.7",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^18.0.0"
       }
@@ -499,9 +815,17 @@
       "version": "5.0.2",
       "license": "MIT"
     },
-    "node_modules/asynckit": {
-      "version": "0.4.0",
-      "license": "MIT"
+    "node_modules/aria-hidden": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/aria-hidden/-/aria-hidden-1.2.6.tgz",
+      "integrity": "sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/autoprefixer": {
       "version": "10.4.23",
@@ -555,15 +879,6 @@
           "url": "https://github.com/sponsors/ai"
         }
       ]
-    },
-    "node_modules/axios": {
-      "version": "1.13.2",
-      "license": "MIT",
-      "dependencies": {
-        "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.4",
-        "proxy-from-env": "^1.1.0"
-      }
     },
     "node_modules/baseline-browser-mapping": {
       "version": "2.9.11",
@@ -642,17 +957,6 @@
         }
       ]
     },
-    "node_modules/call-bind-apply-helpers": {
-      "version": "1.0.2",
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0",
-        "function-bind": "^1.1.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
     "node_modules/camelcase-css": {
       "version": "2.0.1",
       "license": "MIT",
@@ -682,6 +986,20 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/chokidar/node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/chokidar/node_modules/glob-parent": {
       "version": "5.1.2",
       "license": "ISC",
@@ -692,18 +1010,20 @@
         "node": ">= 6"
       }
     },
-    "node_modules/classnames": {
-      "version": "2.5.1",
-      "license": "MIT"
-    },
-    "node_modules/combined-stream": {
-      "version": "1.0.8",
+    "node_modules/cmdk": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cmdk/-/cmdk-1.1.1.tgz",
+      "integrity": "sha512-Vsv7kFaXm+ptHDMZ7izaRsP70GgrW9NBNGswt9OZaVBLlE0SNpDq8eu/VGXyF9r7M0azK3Wy7OlYXsuyYLFzHg==",
       "license": "MIT",
       "dependencies": {
-        "delayed-stream": "~1.0.0"
+        "@radix-ui/react-compose-refs": "^1.1.1",
+        "@radix-ui/react-dialog": "^1.1.6",
+        "@radix-ui/react-id": "^1.1.0",
+        "@radix-ui/react-primitive": "^2.0.2"
       },
-      "engines": {
-        "node": ">= 0.8"
+      "peerDependencies": {
+        "react": "^18 || ^19 || ^19.0.0-rc",
+        "react-dom": "^18 || ^19 || ^19.0.0-rc"
       }
     },
     "node_modules/commander": {
@@ -730,7 +1050,7 @@
     },
     "node_modules/csstype": {
       "version": "3.2.3",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/debug": {
@@ -749,12 +1069,11 @@
         }
       }
     },
-    "node_modules/delayed-stream": {
-      "version": "1.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.4.0"
-      }
+    "node_modules/detect-node-es": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
+      "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==",
+      "license": "MIT"
     },
     "node_modules/didyoumean": {
       "version": "1.2.2",
@@ -764,58 +1083,9 @@
       "version": "1.1.3",
       "license": "MIT"
     },
-    "node_modules/dunder-proto": {
-      "version": "1.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "call-bind-apply-helpers": "^1.0.1",
-        "es-errors": "^1.3.0",
-        "gopd": "^1.2.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
     "node_modules/electron-to-chromium": {
       "version": "1.5.267",
       "license": "ISC"
-    },
-    "node_modules/es-define-property": {
-      "version": "1.0.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/es-errors": {
-      "version": "1.3.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/es-object-atoms": {
-      "version": "1.1.1",
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/es-set-tostringtag": {
-      "version": "2.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0",
-        "get-intrinsic": "^1.2.6",
-        "has-tostringtag": "^1.0.2",
-        "hasown": "^2.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
     },
     "node_modules/esbuild": {
       "version": "0.18.20",
@@ -1253,38 +1523,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/follow-redirects": {
-      "version": "1.15.11",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://github.com/sponsors/RubenVerborgh"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=4.0"
-      },
-      "peerDependenciesMeta": {
-        "debug": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/form-data": {
-      "version": "4.0.5",
-      "license": "MIT",
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/fraction.js": {
       "version": "5.3.4",
       "license": "MIT",
@@ -1295,9 +1533,6 @@
         "type": "github",
         "url": "https://github.com/sponsors/rawify"
       }
-    },
-    "node_modules/fsevents": {
-      "optional": true
     },
     "node_modules/function-bind": {
       "version": "1.1.2",
@@ -1314,37 +1549,13 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/get-intrinsic": {
-      "version": "1.3.0",
-      "license": "MIT",
-      "dependencies": {
-        "call-bind-apply-helpers": "^1.0.2",
-        "es-define-property": "^1.0.1",
-        "es-errors": "^1.3.0",
-        "es-object-atoms": "^1.1.1",
-        "function-bind": "^1.1.2",
-        "get-proto": "^1.0.1",
-        "gopd": "^1.2.0",
-        "has-symbols": "^1.1.0",
-        "hasown": "^2.0.2",
-        "math-intrinsics": "^1.1.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/get-proto": {
+    "node_modules/get-nonce": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-nonce/-/get-nonce-1.0.1.tgz",
+      "integrity": "sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==",
       "license": "MIT",
-      "dependencies": {
-        "dunder-proto": "^1.0.1",
-        "es-object-atoms": "^1.0.0"
-      },
       "engines": {
-        "node": ">= 0.4"
+        "node": ">=6"
       }
     },
     "node_modules/glob-parent": {
@@ -1355,39 +1566,6 @@
       },
       "engines": {
         "node": ">=10.13.0"
-      }
-    },
-    "node_modules/gopd": {
-      "version": "1.2.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/has-symbols": {
-      "version": "1.1.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/has-tostringtag": {
-      "version": "1.0.2",
-      "license": "MIT",
-      "dependencies": {
-        "has-symbols": "^1.0.3"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/hasown": {
@@ -1450,6 +1628,7 @@
     "node_modules/jiti": {
       "version": "1.21.7",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -1494,10 +1673,6 @@
       "version": "1.2.4",
       "license": "MIT"
     },
-    "node_modules/lodash.throttle": {
-      "version": "4.1.1",
-      "license": "MIT"
-    },
     "node_modules/loose-envify": {
       "version": "1.4.0",
       "license": "MIT",
@@ -1516,13 +1691,6 @@
         "yallist": "^3.0.2"
       }
     },
-    "node_modules/math-intrinsics": {
-      "version": "1.1.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
     "node_modules/merge2": {
       "version": "1.4.1",
       "license": "MIT",
@@ -1539,23 +1707,6 @@
       },
       "engines": {
         "node": ">=8.6"
-      }
-    },
-    "node_modules/mime-db": {
-      "version": "1.52.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/mime-types": {
-      "version": "2.1.35",
-      "license": "MIT",
-      "dependencies": {
-        "mime-db": "1.52.0"
-      },
-      "engines": {
-        "node": ">= 0.6"
       }
     },
     "node_modules/ms": {
@@ -1662,6 +1813,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -1800,6 +1952,7 @@
     "node_modules/postcss-selector-parser": {
       "version": "6.1.2",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -1810,19 +1963,6 @@
     },
     "node_modules/postcss-value-parser": {
       "version": "4.2.0",
-      "license": "MIT"
-    },
-    "node_modules/prop-types": {
-      "version": "15.8.1",
-      "license": "MIT",
-      "dependencies": {
-        "loose-envify": "^1.4.0",
-        "object-assign": "^4.1.1",
-        "react-is": "^16.13.1"
-      }
-    },
-    "node_modules/proxy-from-env": {
-      "version": "1.1.0",
       "license": "MIT"
     },
     "node_modules/queue-microtask": {
@@ -1846,6 +1986,7 @@
     "node_modules/react": {
       "version": "18.3.1",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -1857,6 +1998,7 @@
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -1873,23 +2015,59 @@
         "react": "*"
       }
     },
-    "node_modules/react-intersection-observer": {
-      "version": "8.34.0",
-      "license": "MIT",
-      "peerDependencies": {
-        "react": "^15.0.0 || ^16.0.0 || ^17.0.0|| ^18.0.0"
-      }
-    },
-    "node_modules/react-is": {
-      "version": "16.13.1",
-      "license": "MIT"
-    },
     "node_modules/react-refresh": {
       "version": "0.17.0",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-remove-scroll": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.7.2.tgz",
+      "integrity": "sha512-Iqb9NjCCTt6Hf+vOdNIZGdTiH1QSqr27H/Ek9sv/a97gfueI/5h1s3yRi1nngzMUaOOToin5dI1dXKdXiF+u0Q==",
+      "license": "MIT",
+      "dependencies": {
+        "react-remove-scroll-bar": "^2.3.7",
+        "react-style-singleton": "^2.2.3",
+        "tslib": "^2.1.0",
+        "use-callback-ref": "^1.3.3",
+        "use-sidecar": "^1.1.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-remove-scroll-bar": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/react-remove-scroll-bar/-/react-remove-scroll-bar-2.3.8.tgz",
+      "integrity": "sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==",
+      "license": "MIT",
+      "dependencies": {
+        "react-style-singleton": "^2.2.2",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/react-router": {
@@ -1920,26 +2098,26 @@
         "react-dom": ">=16.8"
       }
     },
-    "node_modules/react-scroll": {
-      "version": "1.9.3",
+    "node_modules/react-style-singleton": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/react-style-singleton/-/react-style-singleton-2.2.3.tgz",
+      "integrity": "sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ==",
       "license": "MIT",
       "dependencies": {
-        "lodash.throttle": "^4.1.1",
-        "prop-types": "^15.7.2"
+        "get-nonce": "^1.0.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
       },
       "peerDependencies": {
-        "react": "^15.5.4 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
-        "react-dom": "^15.5.4 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
-      }
-    },
-    "node_modules/react-vertical-timeline-component": {
-      "version": "3.6.0",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "dependencies": {
-        "classnames": "^2.2.6",
-        "prop-types": "^15.7.2",
-        "react-intersection-observer": "^8.26.2"
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/read-cache": {
@@ -2173,6 +2351,7 @@
     "node_modules/tinyglobby/node_modules/picomatch": {
       "version": "4.0.3",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -2193,6 +2372,12 @@
     "node_modules/ts-interface-checker": {
       "version": "0.1.13",
       "license": "Apache-2.0"
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
     },
     "node_modules/typed.js": {
       "version": "2.1.0",
@@ -2237,6 +2422,49 @@
       },
       "peerDependencies": {
         "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/use-callback-ref": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.3.3.tgz",
+      "integrity": "sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/use-sidecar": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/use-sidecar/-/use-sidecar-1.1.3.tgz",
+      "integrity": "sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ==",
+      "license": "MIT",
+      "dependencies": {
+        "detect-node-es": "^1.1.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/util-deprecate": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,23 +9,21 @@
     "preview": "vite preview"
   },
   "dependencies": {
-      "react": "^18.2.0",
-      "react-dom": "^18.2.0",
-      "axios": "^1.6.0",
-      "react-icons": "^4.11.0",
-      "react-router-dom": "^6.20.0",
-      "react-scroll": "^1.9.0",
-      "typed.js": "^2.1.0",
-      "react-vertical-timeline-component": "^3.6.0",
-      "tailwindcss": "^3.3.5",
-      "postcss-nesting": "^12.0.1",
-      "autoprefixer": "^10.4.16"
-    },
+    "autoprefixer": "^10.4.16",
+    "cmdk": "^1.1.1",
+    "postcss-nesting": "^12.0.1",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-icons": "^4.11.0",
+    "react-router-dom": "^6.20.0",
+    "tailwindcss": "^3.3.5",
+    "typed.js": "^2.1.0"
+  },
   "devDependencies": {
-    "typescript": "^5.0.2",
-    "vite": "^4.4.5",
     "@types/react": "^18.2.15",
     "@types/react-dom": "^18.2.7",
-    "@vitejs/plugin-react": "^4.0.3"
+    "@vitejs/plugin-react": "^4.0.3",
+    "typescript": "^5.0.2",
+    "vite": "^4.4.5"
   }
 }

--- a/frontend/public/favicon.svg
+++ b/frontend/public/favicon.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" width="100" height="100">
+  <rect width="100" height="100" rx="24" fill="#1D1E20"/>
+  <text x="50" y="50" dy="0.35em" text-anchor="middle"
+        font-family="'JetBrains Mono', ui-monospace, Menlo, monospace"
+        font-size="52" font-weight="700" fill="#F9FAFB" letter-spacing="-2">jl</text>
+  <circle cx="78" cy="26" r="8" fill="#2CB56B"/>
+</svg>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,39 +1,49 @@
-import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
-import Navbar from './components/Navbar';
-import Experience from './components/Experience';
-import AboutMe from './components/AboutMe';
-import Intro from './components/Intro';
-import Projects from './components/Projects';
-import Footer from './components/Footer';
-import Sheflang from './components/Sheflang';
+import { BrowserRouter as Router, Routes, Route } from 'react-router-dom'
+import { ThemeProvider } from './lib/theme'
+import Navbar from './components/Navbar'
+import Intro from './components/Intro'
+import AboutMe from './components/AboutMe'
+import Experience from './components/Experience'
+import Projects from './components/Projects'
+import Signals from './components/Signals'
+import Contact from './components/Contact'
+import Footer from './components/Footer'
+import Sheflang from './components/Sheflang'
+import ScrollProgress from './components/ScrollProgress'
+import CommandPalette from './components/CommandPalette'
+
+function Home() {
+  return (
+    <>
+      <Intro />
+      <AboutMe />
+      <Experience />
+      <Projects />
+      <Signals />
+      <Contact />
+    </>
+  )
+}
 
 function App() {
   return (
-    <Router>
-      <div className="flex flex-col min-h-screen">
-        <Navbar />
-
-        <div className="flex-grow mt-16">
-          <Routes>
-            <Route
-              path="/"
-              element={
-                <>
-                  <Intro />
-                  <AboutMe />
-                  <Experience />
-                  <Projects />
-                </>
-              }
-            />
-            <Route path="/sheflang" element={<Sheflang />} />
-          </Routes>
+    <ThemeProvider>
+      <Router>
+        <ScrollProgress />
+        <CommandPalette />
+        <div className="flex min-h-screen flex-col bg-canvas">
+          <Navbar />
+          <main className="flex-grow pt-16">
+            <Routes>
+              <Route path="/" element={<Home />} />
+              <Route path="/sheflang" element={<Sheflang />} />
+            </Routes>
+          </main>
+          <Footer />
         </div>
-
-        <Footer />
-      </div>
-    </Router>
-  );
+      </Router>
+    </ThemeProvider>
+  )
 }
 
-export default App;
+export default App

--- a/frontend/src/components/AboutMe.tsx
+++ b/frontend/src/components/AboutMe.tsx
@@ -1,131 +1,104 @@
-import headshot from "../assets/headshot.jpg";
-import { useEffect, useRef } from "react";
-import Typed from 'typed.js';
-import { FaInstagram } from 'react-icons/fa';
-import { AiOutlineMail } from 'react-icons/ai';
+import { useEffect, useRef } from 'react'
+import Typed from 'typed.js'
+import headshot from '../assets/headshot.jpg'
+import { Section, Reveal } from './primitives'
+
+const linkClass =
+  'font-medium text-link underline decoration-link/25 underline-offset-[3px] transition-colors hover:text-link-hover hover:decoration-link/60'
 
 const AboutMe = () => {
-  const emailAddress = 'langlois.j@northeastern.edu';
-
-  const handleEmailClick = () => {
-    window.location.href = `mailto:${emailAddress}`;
-  };
-
-  const interestsRef = useRef<HTMLSpanElement>(null);
-  const typed = useRef<Typed | null>(null);
+  const interestsRef = useRef<HTMLSpanElement>(null)
 
   useEffect(() => {
-    const options = {
+    const typed = new Typed(interestsRef.current, {
       strings: [
-        "Bouldering", "Ping Pong", "Music", "Math", "Hiking", 
-        "Fortnite", "National Parks", "Minecraft", "Swimming", 
-        "Philosophy", "Among Us", "HSY's"
+        'bouldering',
+        'ping pong',
+        'hiking national parks',
+        'cooking',
+        'swimming',
+        'Minecraft',
+        'Fortnite',
+        'Clash of Clans',
+        'philosophy',
       ],
-      typeSpeed: 60,
-      backSpeed: 30,
+      typeSpeed: 55,
+      backSpeed: 28,
+      backDelay: 1400,
       loop: true,
-    };
-
-    typed.current = new Typed(interestsRef.current, options);
-
-    return () => {
-      typed.current?.destroy();
-    };
-  }, []);
+    })
+    return () => typed.destroy()
+  }, [])
 
   return (
-    <section id="about-me" className="py-20 px-6 max-w-6xl mx-auto">
-      <div className="flex items-center mb-12">
-        <h2 className="text-3xl md:text-4xl font-bold text-slate-100 whitespace-nowrap">
-          <span className="font-mono text-teal-400 text-2xl mr-2">01.</span>
-          About Me
-        </h2>
-        <div className="h-[1px] bg-slate-700 w-full ml-6"></div>
-      </div>
-
-      <div className="flex flex-col lg:flex-row gap-12 items-start">
-        <div className="lg:w-2/3 space-y-6">
-          <p className="text-slate-400 text-lg leading-relaxed">
-            I am an Honors Computer Science and Math student at{" "}
-            <a 
-              href="https://www.northeastern.edu/" 
-              className="text-[#e31c25] hover:brightness-125 transition-all font-semibold underline decoration-[#e31c25]/30 underline-offset-4"
-            >
-              Northeastern University
-            </a>. 
-            I'm currently in my third year, seeking software engineering internships for{" "}
-            <span className="text-slate-100 font-bold border-b border-teal-400/50">Summer 2026</span>{" "}
-            and upcoming full-time roles.
-          </p>
-
-          <p className="text-slate-400 text-lg leading-relaxed">
-            Previously, I worked as a Software Engineer Co-op at{" "}
-            <a href="https://www.smartleaf.com/" className="text-green-400 font-semibold hover:underline decoration-green-400/30">
-              Smartleaf
-            </a>, 
-            building core features for their Advisor Portal. Before that, I supported the CERT Cyber Mission Readiness team at the{" "}
-            <span className="text-slate-300 font-semibold border-b border-slate-500/30 hover:underline"><a href="https://sei.cmu.edu/" target="_blank" rel="noopener noreferrer">SEI @ CMU</a></span>.
-          </p>
-
-          <div className="bg-slate-800/40 border border-slate-700/50 p-6 rounded-xl backdrop-blur-sm">
-            <p className="text-slate-400 text-lg leading-relaxed">
-              Currently, I serve as a{" "}
-              <span className="text-slate-100 font-semibold">Technical Lead & Head of DevOps</span> 
-              {" "}at{" "}
-              <a href="https://www.sandboxnu.com/" className="text-blue-400 font-semibold hover:text-blue-300 transition-colors hover:underline decoration-blue-400/30">
-                Sandbox @ Northeastern
-              </a>, 
-              leading the development of student platforms and managing infrastructure. I am also working as a 
-              <span className="text-slate-100 font-semibold"> Software Engineering Co-op</span> 
-              {" "}at{" "}
-              <a href="https://emoneyadvisor.com/" className="text-blue-400 font-semibold hover:text-blue-300 transition-colors hover:underline decoration-blue-400/30">
-                eMoney Advisors.
-              </a>
+    <Section id="about" index="01" title="About">
+      <div className="flex flex-col-reverse gap-8 sm:flex-row sm:items-start sm:gap-10">
+        <Reveal className="flex-1">
+          <div className="space-y-5 text-[16px] leading-[1.65] text-body">
+            <p>
+              I&rsquo;m a third-year Honors student at Northeastern studying
+              computer science and mathematics (3.97 GPA). Right now I&rsquo;m a
+              software engineer co-op at{' '}
+              <span className="font-medium text-ink">Klaviyo</span>, working on
+              KSocial.
             </p>
+            <p>
+              Before this I built advisor tooling at{' '}
+              <span className="font-medium text-ink">eMoney</span> and{' '}
+              <span className="font-medium text-ink">Smartleaf</span>, supported
+              the CERT cyber mission readiness team at the{' '}
+              <a
+                href="https://sei.cmu.edu/"
+                target="_blank"
+                rel="noreferrer"
+                className={linkClass}
+              >
+                SEI at Carnegie Mellon
+              </a>
+              , and did robotics work at Oak Ridge National Laboratory. On
+              campus I&rsquo;m technical lead and head of DevOps at{' '}
+              <a
+                href="https://www.sandboxnu.com/"
+                target="_blank"
+                rel="noreferrer"
+                className={linkClass}
+              >
+                Sandbox
+              </a>
+              , Northeastern&rsquo;s student-led software consultancy.
+            </p>
+            <p>
+              I care about clean systems, fast feedback loops, and shipping
+              tools people actually use.
+            </p>
+
+            <div className="flex items-baseline gap-2.5 pt-2 font-mono text-[13px]">
+              <span className="text-[11px] uppercase tracking-label text-muted">
+                Off the clock
+              </span>
+              <span className="text-line">/</span>
+              <span className="text-ink">
+                <span ref={interestsRef} />
+              </span>
+            </div>
           </div>
+        </Reveal>
 
-          <p className="text-slate-400 text-lg leading-relaxed">
-            Aside from CS, I'm a member of the professional business fraternity{" "}
-            <span className="text-amber-400 font-semibold hover:underline"><a href="https://www.neuakpsi.org/" target="_blank" rel="noopener noreferrer">Alpha Kappa Psi</a></span>. 
-            When I'm not coding, you can find me hiking, climbing, or swimming!
-          </p>
-        </div>
-
-        <div className="lg:w-1/3 w-full flex flex-col items-center">
-          <div className="relative group">
-            <div className="absolute -inset-1 bg-gradient-to-r from-teal-500 to-blue-600 rounded-lg blur opacity-25 group-hover:opacity-50 transition duration-1000 group-hover:duration-200"></div>
-            
+        <Reveal delay={80} className="shrink-0">
+          <figure className="w-[150px] sm:w-[168px]">
             <img
               src={headshot}
-              alt="Jake Langlois Headshot"
-              className="relative rounded-lg w-64 h-auto object-cover grayscale hover:grayscale-0 transition-all duration-500 border border-slate-700"
+              alt="Jake Langlois"
+              className="w-full rounded-lg border border-hairline object-cover grayscale transition-[filter,transform] duration-500 ease-out hover:grayscale-0"
             />
-          </div>
-
-          <div className="mt-8 text-center">
-            <div className="flex items-center justify-center gap-4 mb-2 text-slate-300">
-              <button onClick={handleEmailClick} className="hover:text-teal-400 transition-colors">
-                <AiOutlineMail size={28} />
-              </button>
-              <h3 className="text-xl font-mono text-slate-200 uppercase tracking-widest">
-                Talk to me about:
-              </h3>
-              <a href="https://www.instagram.com/jake.langlois1/" target="_blank" className="hover:text-pink-500 transition-colors">
-                <FaInstagram size={26} />
-              </a>
-            </div>
-            
-            <div className="h-12 flex items-center justify-center">
-               <span 
-                ref={interestsRef} 
-                className="text-3xl font-bold bg-gradient-to-r from-teal-400 to-blue-500 bg-clip-text text-transparent"
-               ></span>
-            </div>
-          </div>
-        </div>
+            <figcaption className="mt-2.5 text-center font-mono text-[11px] text-muted">
+              Boston, MA
+            </figcaption>
+          </figure>
+        </Reveal>
       </div>
-    </section>
-  );
-};
+    </Section>
+  )
+}
 
-export default AboutMe;
+export default AboutMe

--- a/frontend/src/components/ClashStats.tsx
+++ b/frontend/src/components/ClashStats.tsx
@@ -1,103 +1,196 @@
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState, ReactNode } from 'react'
+import { Reveal } from './primitives'
+import { useCountUp } from '../lib/useCountUp'
 
-const ClashStats = () => {
-  const [data, setData] = useState<any>(null);
-  const [loading, setLoading] = useState(true);
+const ENDPOINT =
+  'https://portfolio-backend-u4bb.onrender.com/api/clash/%23200VUR9YR'
 
-  useEffect(() => {
-    fetch('https://portfolio-backend-u4bb.onrender.com/api/clash/%23200VUR9YR')
-      .then((res) => res.json())
-      .then((data) => {
-        setData(data);
-        setLoading(false);
-      })
-      .catch((err) => {
-        console.error("Error fetching Clash stats:", err);
-        setLoading(false);
-      });
-  }, []);
+const FEATURED_HEROES = [
+  'Barbarian King',
+  'Archer Queen',
+  'Grand Warden',
+  'Royal Champion',
+]
 
-  if (loading) return <div className="animate-pulse text-slate-500 font-mono text-xs text-center py-10">Syncing Strategic Data...</div>;
-  if (!data) return null;
+type Hero = { name: string; level: number }
 
-  const heroes = data.heroes?.filter((h: any) =>
-    ["Barbarian King", "Archer Queen", "Grand Warden", "Royal Champion"].includes(h.name)
-  );
+const Panel = ({ children }: { children: ReactNode }) => (
+  <div className="overflow-hidden rounded-lg border border-hairline bg-surface shadow-panel">
+    {children}
+  </div>
+)
 
-  const featuredAchievement = data.achievements[(data.achievements.length) - 1];
-
+const Header = ({ state }: { state: 'live' | 'syncing' | 'offline' }) => {
+  const dot =
+    state === 'live'
+      ? 'bg-signal'
+      : state === 'syncing'
+        ? 'bg-faint'
+        : 'bg-poppy'
+  const label =
+    state === 'live' ? 'LIVE' : state === 'syncing' ? 'SYNC' : 'OFFLINE'
   return (
-    <div className="space-y-4">
-      <div className="flex items-center justify-between px-1">
-        <div className="flex items-center gap-3">
-          <div className="relative flex items-center justify-center">
-            <span className="text-xl">🛡️</span>
-            <span className="absolute -top-1 -right-2 bg-blue-500 text-[9px] font-bold px-1 rounded-sm text-white border border-blue-400">
-              {data.expLevel}
-            </span>
-          </div>
-          <span className="text-xs font-mono text-slate-400 uppercase tracking-widest">LVL {data.expLevel}</span>
-        </div>
-        
-        <div className="flex flex-col items-end">
-          <span className="text-[10px] font-mono text-teal-400 font-bold uppercase tracking-tighter">
-            {data.clan?.name || 'Independent'}
-          </span>
-          <span className="text-[9px] text-slate-500 uppercase tracking-widest">
-            TH {data.townHallLevel} • CLAN LVL {data.clan?.clanLevel || 0}
-          </span>
-        </div>
+    <div className="flex items-center justify-between border-b border-hairline px-4 py-2.5">
+      <div className="flex items-center gap-2.5">
+        <span className="relative flex h-[7px] w-[7px]">
+          {state === 'live' && (
+            <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-signal/60" />
+          )}
+          <span
+            className={`relative inline-flex h-[7px] w-[7px] rounded-full ${dot}`}
+          />
+        </span>
+        <span className="font-mono text-[10px] font-semibold uppercase tracking-label text-muted">
+          {label}
+        </span>
+        <span className="font-mono text-[11px] text-body">Clash of Clans</span>
       </div>
+      <span className="font-mono text-[10px] uppercase tracking-label text-faint">
+        Supercell API
+      </span>
+    </div>
+  )
+}
 
-      <div className="grid grid-cols-2 gap-3">
-        <div className="bg-slate-800/30 p-3 rounded-xl border border-slate-700/50">
-          <p className="text-[9px] uppercase tracking-[0.2em] text-slate-500 mb-1">Trophies</p>
-          <p className="text-xl font-bold text-amber-400 tabular-nums">
-            {data.trophies > 0 ? data.trophies : data.bestTrophies}
-          </p>
-        </div>
-        <div className="bg-slate-800/30 p-3 rounded-xl border border-slate-700/50">
-          <p className="text-[9px] uppercase tracking-[0.2em] text-slate-500 mb-1">War Stars</p>
-          <p className="text-xl font-bold text-slate-100 tabular-nums">{data.warStars}</p>
-        </div>
+const Stat = ({ label, value }: { label: string; value: number }) => {
+  const n = useCountUp(value, true)
+  return (
+    <div className="px-4 py-3.5">
+      <div className="font-mono text-[10px] uppercase tracking-label text-muted">
+        {label}
       </div>
-      <div className="bg-slate-900/40 p-3 rounded-xl border border-slate-800/50">
-        <div className="flex items-center gap-2 mb-3">
-          <p className="text-[9px] uppercase tracking-widest text-slate-500">Hero Progress</p>
-          <div className="h-[1px] flex-grow bg-slate-800"></div>
-        </div>
-        <div className="grid grid-cols-2 gap-x-4 gap-y-2">
-          {heroes.map((hero: any) => (
-            <div key={hero.name} className="flex justify-between items-center bg-slate-800/20 px-2 py-1 rounded">
-              <span className="text-[10px] text-slate-400">
-                {hero.name}
-              </span>
-              <span className="text-[10px] font-mono font-bold text-teal-400">
-                LVL {hero.level}
-              </span>
-            </div>
-          ))}
-        </div>
-      </div>
-
-      <div className="bg-gradient-to-br from-slate-800/50 to-slate-900/50 p-3 rounded-xl border border-teal-500/20">
-        <div className="flex items-center gap-2 mb-1">
-          <span className="text-xs">🏆</span>
-          <p className="text-[9px] uppercase tracking-widest text-teal-500 font-bold">Latest Milestone</p>
-        </div>
-        <p className="text-xs text-slate-200 font-medium mb-1">{featuredAchievement?.name}</p>
-        <p className="text-[10px] text-slate-500 leading-tight italic">
-          {featuredAchievement?.info}
-        </p>
-      </div>
-
-      <div className="text-center pt-1">
-         <p className="text-[8px] uppercase tracking-[0.3em] text-slate-600">
-           Network ID: {data.tag}
-         </p>
+      <div className="tnum mt-1.5 text-[22px] font-semibold leading-none text-ink">
+        {n.toLocaleString('en-US')}
       </div>
     </div>
-  );
-};
+  )
+}
 
-export default ClashStats;
+const ClashStats = () => {
+  const [data, setData] = useState<any>(null)
+  const [status, setStatus] = useState<'loading' | 'ok' | 'error'>('loading')
+
+  useEffect(() => {
+    let alive = true
+    fetch(ENDPOINT)
+      .then((res) => (res.ok ? res.json() : Promise.reject(res.status)))
+      .then((json) => {
+        if (!alive) return
+        setData(json)
+        setStatus('ok')
+      })
+      .catch(() => alive && setStatus('error'))
+    return () => {
+      alive = false
+    }
+  }, [])
+
+  if (status === 'loading') {
+    return (
+      <Reveal>
+        <Panel>
+          <Header state="syncing" />
+          <div className="animate-pulse px-4 py-10 text-center font-mono text-[11px] uppercase tracking-label text-faint">
+            Syncing live data&hellip;
+          </div>
+        </Panel>
+      </Reveal>
+    )
+  }
+
+  if (status === 'error' || !data) {
+    return (
+      <Reveal>
+        <Panel>
+          <Header state="offline" />
+          <div className="px-4 py-8 text-center font-mono text-[11px] uppercase tracking-label text-faint">
+            Feed unavailable &mdash; the free backend may be asleep.
+          </div>
+        </Panel>
+      </Reveal>
+    )
+  }
+
+  const trophies = data.trophies > 0 ? data.trophies : data.bestTrophies
+  const heroes: Hero[] = (data.heroes ?? []).filter((h: Hero) =>
+    FEATURED_HEROES.includes(h.name),
+  )
+  const maxHeroLevel = Math.max(1, ...heroes.map((h) => h.level))
+  const latest = data.achievements?.[data.achievements.length - 1]
+
+  return (
+    <Reveal>
+      <Panel>
+        <Header state="live" />
+
+        {/* Stat grid */}
+        <div className="grid grid-cols-2 divide-x divide-hairline sm:grid-cols-4">
+          <div className="divide-y divide-hairline sm:divide-y-0">
+            <Stat label="Town Hall" value={data.townHallLevel ?? 0} />
+          </div>
+          <div>
+            <Stat label="Trophies" value={trophies ?? 0} />
+          </div>
+          <div className="border-t border-hairline sm:border-t-0">
+            <Stat label="War Stars" value={data.warStars ?? 0} />
+          </div>
+          <div className="border-t border-hairline sm:border-t-0">
+            <Stat label="XP Level" value={data.expLevel ?? 0} />
+          </div>
+        </div>
+
+        {/* Heroes */}
+        {heroes.length > 0 && (
+          <div className="border-t border-hairline px-4 py-4">
+            <div className="mb-3 flex items-center gap-3">
+              <span className="font-mono text-[10px] uppercase tracking-label text-muted">
+                Heroes
+              </span>
+              <span className="h-px flex-grow bg-hairline" />
+              {data.clan?.name && (
+                <span className="font-mono text-[10px] text-faint">
+                  {data.clan.name}
+                </span>
+              )}
+            </div>
+            <div className="grid grid-cols-1 gap-x-6 gap-y-2.5 sm:grid-cols-2">
+              {heroes.map((hero) => (
+                <div key={hero.name} className="flex items-center gap-3">
+                  <span className="w-[112px] shrink-0 truncate text-[12px] text-body">
+                    {hero.name}
+                  </span>
+                  <span className="h-1 flex-grow overflow-hidden rounded-full bg-surface-2">
+                    <span
+                      className="block h-full rounded-full bg-ink/80"
+                      style={{
+                        width: `${(hero.level / maxHeroLevel) * 100}%`,
+                      }}
+                    />
+                  </span>
+                  <span className="tnum w-6 shrink-0 text-right font-mono text-[12px] font-semibold text-ink">
+                    {hero.level}
+                  </span>
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {/* Latest milestone */}
+        {latest && (
+          <div className="flex items-start gap-2 border-t border-hairline px-4 py-3">
+            <span className="mt-[3px] font-mono text-[10px] uppercase tracking-label text-muted">
+              Latest
+            </span>
+            <p className="text-[12px] leading-snug text-body">
+              <span className="font-medium text-ink">{latest.name}</span>
+              {latest.info ? ` — ${latest.info}` : ''}
+            </p>
+          </div>
+        )}
+      </Panel>
+    </Reveal>
+  )
+}
+
+export default ClashStats

--- a/frontend/src/components/CommandPalette.tsx
+++ b/frontend/src/components/CommandPalette.tsx
@@ -1,0 +1,147 @@
+import { useEffect, useState, ReactNode } from 'react'
+import { Command } from 'cmdk'
+import {
+  FiArrowRight,
+  FiGithub,
+  FiLinkedin,
+  FiMail,
+  FiInstagram,
+  FiFileText,
+  FiSun,
+  FiMoon,
+  FiCoffee,
+} from 'react-icons/fi'
+import { useSiteNav, SECTIONS, EXTERNAL } from '../lib/useSiteNav'
+import { useTheme } from '../lib/theme'
+
+const Kbd = ({ children }: { children: ReactNode }) => (
+  <kbd className="rounded border border-hairline bg-surface-2 px-1.5 py-0.5 font-mono text-[10px] leading-none text-muted">
+    {children}
+  </kbd>
+)
+
+const CommandPalette = () => {
+  const [open, setOpen] = useState(false)
+  const { go } = useSiteNav()
+  const { theme, toggle } = useTheme()
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === 'k') {
+        e.preventDefault()
+        setOpen((o) => !o)
+      }
+    }
+    const onOpen = () => setOpen(true)
+    document.addEventListener('keydown', onKey)
+    window.addEventListener('cmdk:open', onOpen)
+    return () => {
+      document.removeEventListener('keydown', onKey)
+      window.removeEventListener('cmdk:open', onOpen)
+    }
+  }, [])
+
+  const run = (fn: () => void) => {
+    setOpen(false)
+    window.setTimeout(fn, 10)
+  }
+
+  const Item = ({
+    icon,
+    label,
+    onSelect,
+  }: {
+    icon: ReactNode
+    label: string
+    onSelect: () => void
+  }) => (
+    <Command.Item
+      value={label}
+      onSelect={onSelect}
+      className="flex items-center gap-3 rounded-md px-3 py-2.5 text-[14px] text-body data-[selected=true]:text-ink"
+    >
+      <span className="text-muted">{icon}</span>
+      <span className="flex-1">{label}</span>
+    </Command.Item>
+  )
+
+  return (
+    <Command.Dialog
+      open={open}
+      onOpenChange={setOpen}
+      label="Command menu"
+      className="w-full max-w-[560px] overflow-hidden rounded-xl border border-hairline bg-surface shadow-pop animate-pop-in"
+    >
+      <Command.Input
+        placeholder="Search or jump to…"
+        className="w-full border-b border-hairline bg-transparent px-4 py-3.5 text-[15px] text-ink outline-none placeholder:text-faint"
+      />
+      <Command.List className="max-h-[340px] overflow-y-auto p-2">
+        <Command.Empty className="px-3 py-6 text-center text-[13px] text-muted">
+          No results.
+        </Command.Empty>
+
+        <Command.Group heading="Navigate">
+          {SECTIONS.map((s) => (
+            <Item
+              key={s.target}
+              icon={<FiArrowRight size={15} />}
+              label={s.label}
+              onSelect={() => run(() => go(s.target))}
+            />
+          ))}
+          <Item
+            icon={<FiCoffee size={15} />}
+            label="The kitchen"
+            onSelect={() => run(() => go('/sheflang'))}
+          />
+        </Command.Group>
+
+        <Command.Group heading="Links">
+          <Item
+            icon={<FiFileText size={15} />}
+            label="Download résumé"
+            onSelect={() => run(() => window.open(EXTERNAL.resume, '_blank'))}
+          />
+          <Item
+            icon={<FiGithub size={15} />}
+            label="GitHub"
+            onSelect={() => run(() => window.open(EXTERNAL.github, '_blank'))}
+          />
+          <Item
+            icon={<FiLinkedin size={15} />}
+            label="LinkedIn"
+            onSelect={() => run(() => window.open(EXTERNAL.linkedin, '_blank'))}
+          />
+          <Item
+            icon={<FiInstagram size={15} />}
+            label="Instagram"
+            onSelect={() => run(() => window.open(EXTERNAL.instagram, '_blank'))}
+          />
+          <Item
+            icon={<FiMail size={15} />}
+            label="Email me"
+            onSelect={() => run(() => (window.location.href = EXTERNAL.email))}
+          />
+        </Command.Group>
+
+        <Command.Group heading="Theme">
+          <Item
+            icon={theme === 'dark' ? <FiSun size={15} /> : <FiMoon size={15} />}
+            label={`Switch to ${theme === 'dark' ? 'light' : 'dark'} theme`}
+            onSelect={() => run(toggle)}
+          />
+        </Command.Group>
+      </Command.List>
+
+      <div className="flex items-center justify-between border-t border-hairline px-3 py-2 font-mono text-[10px] text-faint">
+        <span>jakelanglois.com</span>
+        <span className="flex items-center gap-1.5">
+          <Kbd>↑↓</Kbd> move <Kbd>↵</Kbd> select <Kbd>esc</Kbd> close
+        </span>
+      </div>
+    </Command.Dialog>
+  )
+}
+
+export default CommandPalette

--- a/frontend/src/components/Contact.tsx
+++ b/frontend/src/components/Contact.tsx
@@ -1,0 +1,72 @@
+import { AiFillGithub, AiFillLinkedin } from 'react-icons/ai'
+import { FiArrowUpRight } from 'react-icons/fi'
+import { Reveal } from './primitives'
+
+const email = 'langlois.j@northeastern.edu'
+
+const Contact = () => {
+  return (
+    <section
+      id="contact"
+      className="mx-auto max-w-content scroll-mt-24 px-6 pb-4 pt-[72px] md:pt-[88px]"
+    >
+      <Reveal>
+        <div className="overflow-hidden rounded-2xl bg-inverse px-7 py-10 text-inverse-fg md:px-11 md:py-14">
+          <span className="font-mono text-eyebrow uppercase tracking-label text-inverse-fg/45">
+            05 · Contact
+          </span>
+          <h2 className="mt-4 max-w-[18ch] text-[30px] font-semibold leading-[1.08] tracking-display md:text-[38px]">
+            Let&rsquo;s build something.
+          </h2>
+          <p className="mt-5 max-w-[48ch] text-[16px] leading-relaxed text-inverse-fg/65">
+            Graduating 2027. I&rsquo;m open to software engineering internships
+            and new-grad roles &mdash; and always up for a good technical
+            conversation. Email is the fastest way to reach me.
+          </p>
+
+          <div className="mt-8 flex flex-wrap items-center gap-3">
+            <a
+              href={`mailto:${email}`}
+              className="inline-flex items-center gap-2 rounded-md bg-inverse-fg px-4 py-2.5 text-[14px] font-medium text-inverse transition-transform duration-200 ease-out hover:-translate-y-0.5"
+            >
+              {email}
+            </a>
+            <a
+              href="Langlois_Resume.pdf"
+              download
+              className="inline-flex items-center gap-1.5 rounded-md border border-inverse-fg/20 px-4 py-2.5 text-[14px] font-medium text-inverse-fg transition-colors hover:bg-inverse-fg/10"
+            >
+              Résumé <FiArrowUpRight size={15} />
+            </a>
+          </div>
+
+          <div className="mt-9 flex items-center gap-5 text-inverse-fg/55">
+            <a
+              href="https://github.com/23langloisj"
+              target="_blank"
+              rel="noreferrer"
+              aria-label="GitHub"
+              className="transition-colors hover:text-inverse-fg"
+            >
+              <AiFillGithub size={20} />
+            </a>
+            <a
+              href="https://www.linkedin.com/in/jacob-langlois/"
+              target="_blank"
+              rel="noreferrer"
+              aria-label="LinkedIn"
+              className="transition-colors hover:text-inverse-fg"
+            >
+              <AiFillLinkedin size={20} />
+            </a>
+            <span className="ml-auto font-mono text-[11px] text-inverse-fg/40">
+              Boston · Greater Pittsburgh
+            </span>
+          </div>
+        </div>
+      </Reveal>
+    </section>
+  )
+}
+
+export default Contact

--- a/frontend/src/components/Experience.tsx
+++ b/frontend/src/components/Experience.tsx
@@ -1,67 +1,59 @@
-import React from 'react';
-import { VerticalTimeline, VerticalTimelineElement } from 'react-vertical-timeline-component';
-import 'react-vertical-timeline-component/style.min.css';
-import experiences, { ExperienceData } from '../extra/experiences.js';
+import { FiArrowUpRight } from 'react-icons/fi'
+import experiences, { ExperienceData } from '../extra/experiences'
+import { Section, Reveal } from './primitives'
 
 const Experience = () => {
   return (
-    <section id="experiences" className="py-20 px-6 max-w-6xl mx-auto">
-      <div className="flex items-center mb-16">
-        <h2 className="text-3xl md:text-4xl font-bold text-slate-100 whitespace-nowrap">
-          <span className="font-mono text-teal-400 text-2xl mr-2">02.</span>
-          Where I’ve Worked
-        </h2>
-        <div className="h-[1px] bg-slate-700 w-full ml-6"></div>
-      </div>
+    <Section
+      id="experience"
+      index="02"
+      title="Experience"
+      action={
+        <a
+          href="https://www.linkedin.com/in/jacob-langlois/"
+          target="_blank"
+          rel="noreferrer"
+          className="link-sweep inline-flex items-center gap-1 font-mono text-[12px] text-link transition-colors hover:text-link-hover"
+        >
+          Full history <FiArrowUpRight size={13} />
+        </a>
+      }
+    >
+      <ol className="border-t border-hairline">
+        {experiences.map((exp: ExperienceData, i) => (
+          <Reveal key={exp.company} delay={Math.min(i * 40, 200)}>
+            <li className="group flex gap-4 border-b border-hairline py-5">
+              <span className="mt-0.5 grid h-9 w-9 shrink-0 place-items-center rounded-md border border-hairline bg-surface font-mono text-[11px] font-semibold text-muted transition-colors duration-200 group-hover:border-line group-hover:text-ink">
+                {exp.mark}
+              </span>
 
-      <VerticalTimeline lineColor='#334155'>
-        {experiences.map((experience: ExperienceData, index) => (
-          <VerticalTimelineElement
-            key={index}
-            date={experience.date}
-            dateClassName="text-slate-400 font-mono text-sm px-4"
-            iconStyle={{ 
-              background: '#0f172a',
-              boxShadow: '0 0 0 4px #2dd4bf, inset 0 2px 0 rgba(0,0,0,.08), 0 3px 0 4px rgba(0,0,0,.05)' 
-            }}
-            contentStyle={{ 
-              background: '#1e293b',
-              color: '#e2e8f0', 
-              boxShadow: 'none',
-              border: '1px solid #334155',
-              borderRadius: '12px',
-              padding: '2rem'
-            }}
-            contentArrowStyle={{ borderRight: '7px solid #334155' }}
-            icon={
-              <div className="flex items-center justify-center w-full h-full p-2">
-                <img 
-                  src={experience.image} 
-                  alt={experience.company} 
-                  className="w-full h-full object-contain rounded-full" 
-                />
-              </div>
-            }
-          >
-            <div className="text-left">
-              <h3 className="text-xl font-bold text-slate-100 mb-1">
-                {experience.role}
-              </h3>
-              <p className="text-teal-400 font-mono text-sm mb-4 !mt-0 uppercase tracking-wider">
-                {experience.company}
-              </p>
-              
-              {experience.description && (
-                <p className="text-slate-400 text-sm leading-relaxed !font-normal">
-                  {experience.description}
+              <div className="flex flex-1 flex-col">
+                <div className="flex flex-wrap items-baseline justify-between gap-x-4 gap-y-0.5">
+                  <h3 className="text-[15px] font-semibold text-ink">
+                    {exp.role}
+                  </h3>
+                  <span className="tnum font-mono text-[12px] text-muted">
+                    {exp.date}
+                  </span>
+                </div>
+
+                <div className="flex flex-wrap items-baseline justify-between gap-x-4">
+                  <span className="text-[13px] text-body">{exp.company}</span>
+                  <span className="font-mono text-[10px] uppercase tracking-label text-faint">
+                    {exp.domain}
+                  </span>
+                </div>
+
+                <p className="mt-1.5 max-w-[58ch] text-[14px] leading-relaxed text-body">
+                  {exp.summary}
                 </p>
-              )}
-            </div>
-          </VerticalTimelineElement>
+              </div>
+            </li>
+          </Reveal>
         ))}
-      </VerticalTimeline>
-    </section>
-  );
+      </ol>
+    </Section>
+  )
 }
 
-export default Experience;
+export default Experience

--- a/frontend/src/components/Footer.tsx
+++ b/frontend/src/components/Footer.tsx
@@ -1,35 +1,74 @@
-import React from 'react';
-import { AiFillGithub, AiFillLinkedin } from 'react-icons/ai';
+import { AiFillGithub, AiFillLinkedin } from 'react-icons/ai'
+import { FaInstagram } from 'react-icons/fa'
+import { AiOutlineMail } from 'react-icons/ai'
+import { FiArrowUp } from 'react-icons/fi'
 
 const Footer = () => {
-    return (
-        <footer className="py-12 px-6 border-t border-slate-800/60 bg-[#0f172a]">
-            <div className="max-w-6xl mx-auto flex flex-col items-center">
-                <div className="flex gap-8 mb-8 text-slate-400">
-                    <a 
-                        href="https://github.com/23langloisj" 
-                        target="_blank" 
-                        className="hover:text-teal-400 transition-colors duration-300"
-                    >
-                        <AiFillGithub size={24} />
-                    </a>
-                    <a 
-                        href="https://www.linkedin.com/in/jacob-langlois/" 
-                        target="_blank" 
-                        className="hover:text-teal-400 transition-colors duration-300"
-                    >
-                        <AiFillLinkedin size={24} />
-                    </a>
-                </div>
-                <p className="font-mono text-sm tracking-widest text-slate-500 uppercase mb-2">
-                    Designed & Built by <span className="text-slate-300">Jake Langlois</span>
-                </p>
-                <p className="text-[10px] font-mono text-slate-600 uppercase tracking-tighter">
-                    React · Tailwind · TypeScript · Framer Motion
-                </p>
-            </div>
-        </footer>
-    );
-};
+  return (
+    <footer className="mx-auto w-full max-w-content px-6 pb-14 pt-[72px] md:pt-[88px]">
+      <div className="border-t border-hairline pt-7">
+        <div className="flex flex-col gap-5 sm:flex-row sm:items-center sm:justify-between">
+          <div className="flex items-center gap-2.5">
+            <span className="grid h-6 w-6 place-items-center rounded bg-ink font-mono text-[11px] font-bold leading-none text-canvas">
+              jl
+            </span>
+            <span className="font-mono text-[12px] text-muted">
+              jakelanglois.com
+            </span>
+          </div>
 
-export default Footer;
+          <div className="flex items-center gap-5 text-muted">
+            <a
+              href="mailto:langlois.j@northeastern.edu"
+              aria-label="Email"
+              className="transition-colors hover:text-ink"
+            >
+              <AiOutlineMail size={19} />
+            </a>
+            <a
+              href="https://github.com/23langloisj"
+              target="_blank"
+              rel="noreferrer"
+              aria-label="GitHub"
+              className="transition-colors hover:text-ink"
+            >
+              <AiFillGithub size={19} />
+            </a>
+            <a
+              href="https://www.linkedin.com/in/jacob-langlois/"
+              target="_blank"
+              rel="noreferrer"
+              aria-label="LinkedIn"
+              className="transition-colors hover:text-ink"
+            >
+              <AiFillLinkedin size={19} />
+            </a>
+            <a
+              href="https://www.instagram.com/jake.langlois1/"
+              target="_blank"
+              rel="noreferrer"
+              aria-label="Instagram"
+              className="transition-colors hover:text-ink"
+            >
+              <FaInstagram size={17} />
+            </a>
+          </div>
+        </div>
+
+        <div className="mt-6 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+          <p className="font-mono text-[11px] text-faint">
+            Designed and built by Jake Langlois · React · TypeScript · Tailwind
+          </p>
+          <button
+            onClick={() => window.scrollTo({ top: 0, behavior: 'smooth' })}
+            className="inline-flex items-center gap-1.5 self-start font-mono text-[11px] uppercase tracking-label text-muted transition-colors hover:text-ink sm:self-auto"
+          >
+            Back to top <FiArrowUp size={12} />
+          </button>
+        </div>
+      </div>
+    </footer>
+  )
+}
+
+export default Footer

--- a/frontend/src/components/Intro.tsx
+++ b/frontend/src/components/Intro.tsx
@@ -1,87 +1,163 @@
+import { useEffect, useRef } from 'react'
 import { AiFillGithub, AiFillLinkedin } from 'react-icons/ai'
-import ClashStats from './ClashStats' // Import your component
+import { FaInstagram } from 'react-icons/fa'
+import { FiArrowUpRight } from 'react-icons/fi'
+import ClashStats from './ClashStats'
+import { Reveal } from './primitives'
+import { useMagnetic } from '../lib/useMagnetic'
+
+const scrollToId = (id: string) =>
+  document.getElementById(id)?.scrollIntoView({ behavior: 'smooth' })
+
+const linkClass =
+  'font-medium text-link underline decoration-link/25 underline-offset-[3px] transition-colors hover:text-link-hover hover:decoration-link/60'
 
 const Intro = () => {
+  const headerRef = useRef<HTMLElement>(null)
+  const magneticRef = useMagnetic<HTMLButtonElement>()
+
+  useEffect(() => {
+    const el = headerRef.current
+    if (!el) return
+    if (window.matchMedia('(hover: none)').matches) return
+    const spot = el.querySelector<HTMLElement>('.spotlight')
+    const onMove = (e: MouseEvent) => {
+      const r = el.getBoundingClientRect()
+      el.style.setProperty('--mx', `${e.clientX - r.left}px`)
+      el.style.setProperty('--my', `${e.clientY - r.top}px`)
+    }
+    const onEnter = () => spot?.classList.add('is-live')
+    const onLeave = () => spot?.classList.remove('is-live')
+    el.addEventListener('mousemove', onMove)
+    el.addEventListener('mouseenter', onEnter)
+    el.addEventListener('mouseleave', onLeave)
+    return () => {
+      el.removeEventListener('mousemove', onMove)
+      el.removeEventListener('mouseenter', onEnter)
+      el.removeEventListener('mouseleave', onLeave)
+    }
+  }, [])
+
   return (
-    <header className="relative min-h-screen flex items-center justify-center bg-[#0f172a] overflow-hidden">
-      {/* Subtle Background Decoration */}
-      <div className="absolute top-1/4 -right-20 w-96 h-96 bg-teal-500/5 rounded-full blur-3xl"></div>
-      <div className="absolute bottom-1/4 -left-20 w-96 h-96 bg-blue-500/5 rounded-full blur-3xl"></div>
+    <header id="top" ref={headerRef} className="relative overflow-hidden">
+      {/* Backdrop: engineering dot-grid + cursor spotlight */}
+      <div aria-hidden className="pointer-events-none absolute inset-0 -z-10">
+        <div className="absolute inset-0 bg-dotgrid opacity-70 [mask-image:radial-gradient(ellipse_75%_55%_at_50%_-5%,#000_5%,transparent_72%)]" />
+        <div className="spotlight" />
+      </div>
 
-      <div className="max-w-6xl mx-auto px-6 grid lg:grid-cols-[1fr_350px] gap-12 items-center">
-        {/* LEFT SIDE: YOUR CORE INFO */}
-        <div className="text-center lg:text-left">
-          <p className="font-mono text-teal-500 text-sm mb-3 tracking-widest uppercase">
-            Nice to meet you
-          </p>
+      <div className="mx-auto max-w-content px-6 pb-2 pt-10 md:pt-14">
+        <Reveal>
+          <div className="mb-5 flex items-center gap-2 font-mono text-eyebrow uppercase tracking-label text-muted">
+            <span>CS + Math</span>
+            <span className="text-line">/</span>
+            <span>Northeastern &rsquo;27</span>
+          </div>
 
-          <h1 className="text-4xl md:text-6xl font-bold text-slate-100 mb-6 tracking-tight">
-            <span className="font-medium text-slate-400">Hi, I'm </span>
+          <h1 className="text-[38px] font-semibold leading-[1.05] tracking-display text-ink md:text-[52px]">
             Jake Langlois
           </h1>
 
-          <p className="text-slate-400 text-lg md:text-xl max-w-lg mx-auto lg:mx-0 leading-relaxed mb-10">
-            I'm an aspiring Software Engineer studying CS and Math at
-            <span className="text-rose-500/90 font-semibold">
-              {' '}
+          <p className="mt-6 max-w-[54ch] text-[17px] leading-[1.65] text-body md:text-[18px]">
+            I&rsquo;m a software engineer studying CS + Math at{' '}
+            <a
+              href="https://www.northeastern.edu/"
+              target="_blank"
+              rel="noreferrer"
+              className={linkClass}
+            >
               Northeastern
-            </span>
-            .
+            </a>
+            . I&rsquo;ve shipped features across fintech and media &mdash;
+            currently building at{' '}
+            <a
+              href="https://www.klaviyo.com/"
+              target="_blank"
+              rel="noreferrer"
+              className={linkClass}
+            >
+              Klaviyo
+            </a>
+            , previously eMoney, Smartleaf, and the SEI at Carnegie Mellon. I
+            like clean systems, fast feedback loops, and tools people actually
+            use.
           </p>
 
-          <div className="flex flex-col lg:flex-row items-center gap-8">
-            <button
-              className="group px-8 py-3 border border-teal-500/50 text-teal-400 text-sm hover:bg-teal-500/10 transition-all duration-300 rounded-lg"
-              onClick={() => {
-                document
-                  .getElementById('projects')
-                  ?.scrollIntoView({ behavior: 'smooth' })
-              }}
-            >
-              Check out my work
-            </button>
+          {/* Availability + actions */}
+          <div className="mt-8 flex flex-wrap items-center gap-x-4 gap-y-4">
+            <span className="inline-flex items-center gap-2 rounded-full border border-hairline bg-surface px-3 py-1.5 text-[13px] text-body">
+              <span className="relative flex h-[7px] w-[7px]">
+                <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-signal/60" />
+                <span className="relative inline-flex h-[7px] w-[7px] rounded-full bg-signal" />
+              </span>
+              Open to opportunities
+            </span>
 
-            <div className="flex items-center space-x-10 text-slate-500">
+            <div className="flex items-center gap-3">
+              <button
+                ref={magneticRef}
+                onClick={() => scrollToId('work')}
+                className="rounded-md bg-ink px-4 py-2.5 text-[14px] font-medium text-canvas transition-transform duration-200 ease-out"
+              >
+                View work
+              </button>
+              <button
+                onClick={() => scrollToId('contact')}
+                className="link-sweep inline-flex items-center gap-1 py-2.5 text-[14px] font-medium text-link transition-colors hover:text-link-hover"
+              >
+                Get in touch <FiArrowUpRight size={15} />
+              </button>
+            </div>
+          </div>
+
+          {/* Socials + ⌘K hint */}
+          <div className="mt-8 flex flex-wrap items-center gap-x-6 gap-y-4">
+            <div className="flex items-center gap-5 text-muted">
               <a
                 href="https://github.com/23langloisj"
                 target="_blank"
-                className="hover:text-white transition-colors text-2xl"
+                rel="noreferrer"
+                aria-label="GitHub"
+                className="transition-colors hover:text-ink"
               >
-                <AiFillGithub />
+                <AiFillGithub size={20} />
               </a>
               <a
                 href="https://www.linkedin.com/in/jacob-langlois/"
                 target="_blank"
-                className="hover:text-white transition-colors text-2xl"
+                rel="noreferrer"
+                aria-label="LinkedIn"
+                className="transition-colors hover:text-ink"
               >
-                <AiFillLinkedin />
+                <AiFillLinkedin size={20} />
+              </a>
+              <a
+                href="https://www.instagram.com/jake.langlois1/"
+                target="_blank"
+                rel="noreferrer"
+                aria-label="Instagram"
+                className="transition-colors hover:text-ink"
+              >
+                <FaInstagram size={18} />
               </a>
             </div>
+
+            <button
+              onClick={() => window.dispatchEvent(new Event('cmdk:open'))}
+              className="hidden items-center gap-1.5 font-mono text-[11px] text-faint transition-colors hover:text-muted sm:inline-flex"
+            >
+              Press
+              <kbd className="rounded border border-hairline bg-surface px-1.5 py-0.5 text-[10px] text-muted">
+                ⌘K
+              </kbd>
+              to jump anywhere
+            </button>
           </div>
-        </div>
+        </Reveal>
 
-        {/* RIGHT SIDE: THE STRATEGIC DATA WIDGET */}
-        <div className="relative group mx-auto lg:mx-0">
-          {/* Modern Glass Wrapper */}
-          <div className="absolute -inset-1 bg-gradient-to-r from-teal-500/20 to-blue-500/20 rounded-2xl blur opacity-75 group-hover:opacity-100 transition duration-1000"></div>
-
-          <div className="relative bg-slate-900/60 backdrop-blur-xl border border-slate-800 p-1 rounded-2xl shadow-2xl">
-            {/* Header for the widget to make it look like a mini-app */}
-            <div className="flex items-center justify-between px-4 py-2 border-b border-slate-800/50">
-              <div className="flex gap-1.5">
-                <div className="w-2 h-2 rounded-full bg-red-500/40"></div>
-                <div className="w-2 h-2 rounded-full bg-amber-500/40"></div>
-                <div className="w-2 h-2 rounded-full bg-teal-500/40"></div>
-              </div>
-              <span className="text-[9px] font-mono text-slate-500 tracking-[0.2em] uppercase">
-                API Live Feed
-              </span>
-            </div>
-
-            <div className="p-2">
-              <ClashStats />
-            </div>
-          </div>
+        {/* Signature: live Clash of Clans readout */}
+        <div className="mt-11 md:mt-14">
+          <ClashStats />
         </div>
       </div>
     </header>

--- a/frontend/src/components/LoreModal.tsx
+++ b/frontend/src/components/LoreModal.tsx
@@ -1,63 +1,66 @@
-import { FiX } from 'react-icons/fi';
+import { useEffect } from 'react'
+import { FiX } from 'react-icons/fi'
+import { FoodItem } from '../extra/food'
 
 export interface ModalProps {
-  showModal: boolean;
-  setShowModal: (show: boolean) => void;
-  lore: string;
-  name: string;
+  item: FoodItem | null
+  onClose: () => void
 }
 
-const Modal = ({ showModal, setShowModal, lore, name }: ModalProps) => {
-  if (!showModal) return null;
+const Modal = ({ item, onClose }: ModalProps) => {
+  useEffect(() => {
+    if (!item) return
+    const onKey = (e: KeyboardEvent) => e.key === 'Escape' && onClose()
+    document.addEventListener('keydown', onKey)
+    document.body.style.overflow = 'hidden'
+    return () => {
+      document.removeEventListener('keydown', onKey)
+      document.body.style.overflow = ''
+    }
+  }, [item, onClose])
 
-  // Close modal when clicking on the backdrop
-  const handleBackdropClick = (e: React.MouseEvent<HTMLDivElement>) => {
-    if (e.target === e.currentTarget) setShowModal(false);
-  };
+  if (!item) return null
 
   return (
-    <div 
-      className="fixed inset-0 z-[100] flex items-center justify-center p-4 bg-slate-950/80 backdrop-blur-sm"
-      onClick={handleBackdropClick}
+    <div
+      className="fixed inset-0 z-[100] flex items-center justify-center bg-black/50 p-4 backdrop-blur-sm"
+      onClick={(e) => e.target === e.currentTarget && onClose()}
     >
-      <div className="relative bg-slate-900 border border-slate-800 w-full max-w-lg rounded-3xl overflow-hidden shadow-2xl transition-all">
-        <div className="h-1.5 w-full bg-gradient-to-r from-teal-400 to-orange-400"></div>
-
-        <div className="p-8 md:p-10">
-          <div className="flex justify-between items-start mb-6">
-            <div>
-              <span className="font-mono text-teal-400 text-xs uppercase tracking-[0.2em] mb-1 block">
-                Dish History
-              </span>
-              <h2 className="text-3xl font-bold text-slate-100 tracking-tight">
-                {name} <span className="text-slate-500 font-light">Lore</span>
-              </h2>
+      <div className="w-full max-w-md overflow-hidden rounded-xl border border-hairline bg-surface shadow-card">
+        <div className="flex items-start justify-between gap-4 border-b border-hairline px-6 py-5">
+          <div>
+            <div className="mb-1.5 font-mono text-eyebrow uppercase tracking-label text-muted">
+              Dish lore
             </div>
-            <button 
-              onClick={() => setShowModal(false)}
-              className="text-slate-500 hover:text-white transition-colors p-1"
-            >
-              <FiX size={24} />
-            </button>
+            <h2 className="text-[20px] font-semibold tracking-heading text-ink">
+              {item.name}
+            </h2>
           </div>
-          <div className="relative">
-            <span className="absolute -top-4 -left-2 text-6xl text-slate-800 font-serif select-none">“</span>
-            <p className="relative text-slate-300 text-lg leading-relaxed italic font-light">
-              {lore}
-            </p>
-          </div>
-          <div className="mt-10 flex justify-end">
-            <button
-              onClick={() => setShowModal(false)}
-              className="px-8 py-3 bg-slate-800 border border-slate-700 text-slate-200 font-mono text-xs uppercase tracking-widest rounded-xl hover:bg-slate-700 hover:border-teal-500/50 transition-all duration-300"
-            >
-              Back to Menu
-            </button>
-          </div>
+          <button
+            onClick={onClose}
+            aria-label="Close"
+            className="grid h-8 w-8 shrink-0 place-items-center rounded-md text-muted transition-colors hover:bg-surface-2 hover:text-ink"
+          >
+            <FiX size={18} />
+          </button>
+        </div>
+
+        <div className="px-6 py-5">
+          <p className="mb-3 text-[13px] text-muted">{item.description}</p>
+          <p className="text-[15px] leading-relaxed text-body">{item.lore}</p>
+        </div>
+
+        <div className="flex justify-end border-t border-hairline px-6 py-4">
+          <button
+            onClick={onClose}
+            className="rounded-md bg-ink px-4 py-2 text-[13px] font-medium text-canvas transition-transform duration-200 ease-out hover:-translate-y-0.5"
+          >
+            Back to menu
+          </button>
         </div>
       </div>
     </div>
-  );
-};
+  )
+}
 
-export default Modal;
+export default Modal

--- a/frontend/src/components/Navbar.tsx
+++ b/frontend/src/components/Navbar.tsx
@@ -1,94 +1,189 @@
-import { useNavigate } from "react-router-dom";
-import { animateScroll as scroll } from "react-scroll";
-import { FiFileText } from 'react-icons/fi'; 
+import { useEffect, useState } from 'react'
+import { useNavigate, useLocation } from 'react-router-dom'
+import { FiMenu, FiX, FiSearch } from 'react-icons/fi'
+import { ThemeToggle } from '../lib/theme'
+
+const navItems = [
+  { label: 'About', target: 'about' },
+  { label: 'Experience', target: 'experience' },
+  { label: 'Work', target: 'work' },
+  { label: 'Kitchen', target: '/sheflang' },
+]
 
 const Navbar = () => {
-  const navItems = [
-    { label: "About", href: "about-me" },
-    { label: "Experience", href: "experiences" },
-    { label: "Projects", href: "projects" },
-    { label: "Food", href: "/sheflang" },
-  ];
+  const navigate = useNavigate()
+  const { pathname } = useLocation()
+  const [scrolled, setScrolled] = useState(false)
+  const [open, setOpen] = useState(false)
+  const [active, setActive] = useState('')
 
-  const resumeLink = "Langlois_Resume.pdf";
-  const navigate = useNavigate();
+  useEffect(() => {
+    const onScroll = () => setScrolled(window.scrollY > 8)
+    onScroll()
+    window.addEventListener('scroll', onScroll, { passive: true })
+    return () => window.removeEventListener('scroll', onScroll)
+  }, [])
 
-  const handleNavClick = (href: string) => {
-    if (href === "/sheflang") {
-      navigate(href);
-      setTimeout(() => {
-        const section = document.getElementById("sheflang");
-        section?.scrollIntoView({ behavior: "smooth", block: "start" });
-      }, 100);
-    } else if (href.startsWith("/")) {
-      navigate(href);
-    } else {
-      if (window.location.pathname !== "/") {
-        navigate("/");
-        setTimeout(() => {
-          const element = document.getElementById(href);
-          if (element) {
-            scroll.scrollTo(element.offsetTop - 100, { duration: 800 });
-          }
-        }, 150);
-      } else {
-        const element = document.getElementById(href);
-        if (element) {
-          scroll.scrollTo(element.offsetTop - 100, { duration: 800 });
-        }
-      }
+  // Scroll-spy: highlight the section currently crossing the viewport middle.
+  useEffect(() => {
+    if (pathname !== '/') {
+      setActive('')
+      return
     }
-  };
+    const ids = ['about', 'experience', 'work']
+    const els = ids
+      .map((id) => document.getElementById(id))
+      .filter((el): el is HTMLElement => Boolean(el))
+    if (!els.length) return
+    const io = new IntersectionObserver(
+      (entries) => {
+        entries.forEach((e) => {
+          if (e.isIntersecting) setActive(e.target.id)
+        })
+      },
+      { rootMargin: '-45% 0px -50% 0px', threshold: 0 },
+    )
+    els.forEach((el) => io.observe(el))
+    return () => io.disconnect()
+  }, [pathname])
+
+  const isActive = (target: string) =>
+    target === '/sheflang' ? pathname === '/sheflang' : active === target
+
+  const scrollToId = (id: string) =>
+    document.getElementById(id)?.scrollIntoView({ behavior: 'smooth' })
+
+  const handleNav = (target: string) => {
+    setOpen(false)
+    if (target.startsWith('/')) {
+      navigate(target)
+      window.scrollTo(0, 0)
+      return
+    }
+    if (pathname !== '/') {
+      navigate('/')
+      setTimeout(() => scrollToId(target), 90)
+    } else {
+      scrollToId(target)
+    }
+  }
+
+  const goHome = () => {
+    setOpen(false)
+    if (pathname === '/') window.scrollTo({ top: 0, behavior: 'smooth' })
+    else {
+      navigate('/')
+      window.scrollTo(0, 0)
+    }
+  }
 
   return (
-    <nav className="fixed top-0 left-0 right-0 z-50 bg-[#0f172a]/80 backdrop-blur-md border-b border-slate-800">
-      <div className="max-w-6xl mx-auto px-6 h-20 flex items-center justify-between">
-        <div
-          className="cursor-pointer group"
-          onClick={() => {
-            if (window.location.pathname === "/") {
-              scroll.scrollToTop({ duration: 800 });
-            } else {
-              navigate("/");
-              // Reset to top instantly on route change
-              window.scrollTo(0, 0);
-            }
-          }}
+    <nav
+      className={`fixed inset-x-0 top-0 z-50 border-b transition-colors duration-300 ${
+        scrolled || open
+          ? 'border-hairline bg-canvas/85 backdrop-blur-md'
+          : 'border-transparent'
+      }`}
+    >
+      <div className="mx-auto flex h-16 max-w-content items-center justify-between px-6">
+        {/* Monogram + wordmark */}
+        <button
+          onClick={goHome}
+          className="group flex items-center gap-2.5"
+          aria-label="Back to top"
         >
-          <div className="text-2xl font-bold tracking-tighter text-slate-100 transition-all group-hover:text-teal-400">
-            <span className="text-teal-400 font-mono text-xl">&lt;</span>
-            lang 
-            <span className="text-teal-400 font-mono text-xl"> /&gt;</span>
-          </div>
-        </div>
+          <span className="grid h-7 w-7 place-items-center rounded-md bg-ink font-mono text-[13px] font-bold leading-none text-canvas transition-transform duration-300 ease-out group-hover:-translate-y-0.5">
+            jl
+          </span>
+          <span className="hidden font-mono text-[13px] text-body transition-colors group-hover:text-ink sm:inline">
+            jakelanglois.com
+          </span>
+        </button>
 
-        <div className="flex items-center gap-8">
-          <ul className="hidden md:flex items-center gap-8">
-            {navItems.map((item, index) => (
-              <li key={index}>
+        <div className="flex items-center gap-1 sm:gap-2">
+          <ul className="hidden items-center md:flex">
+            {navItems.map((item) => (
+              <li key={item.label}>
                 <button
-                  onClick={() => handleNavClick(item.href)}
-                  className="flex items-center gap-2 group"
+                  onClick={() => handleNav(item.target)}
+                  className={`relative rounded-md px-3 py-2 font-mono text-[12px] uppercase tracking-label transition-colors ${
+                    isActive(item.target)
+                      ? 'text-ink'
+                      : 'text-muted hover:text-ink'
+                  }`}
                 >
-                  <span className="font-mono text-teal-400 text-xs"></span>
-                  <span className="text-slate-300 text-sm font-medium tracking-wide uppercase group-hover:text-teal-400 transition-colors">
-                    {item.label}
-                  </span>
+                  {item.label}
+                  <span
+                    className={`absolute -bottom-0.5 left-1/2 h-[2px] -translate-x-1/2 rounded-full bg-link transition-all duration-300 ease-out ${
+                      isActive(item.target) ? 'w-4 opacity-100' : 'w-0 opacity-0'
+                    }`}
+                  />
                 </button>
               </li>
             ))}
           </ul>
-          <a 
-            href={resumeLink} 
-            download 
-            className="px-5 py-2 border border-teal-400 text-teal-400 font-mono text-xs uppercase tracking-widest rounded hover:bg-teal-400/10 transition-all duration-300 flex items-center gap-2"
+
+          <button
+            onClick={() => window.dispatchEvent(new Event('cmdk:open'))}
+            aria-label="Open command menu"
+            className="ml-1 flex items-center gap-2 rounded-md border border-hairline px-2.5 py-1.5 text-muted transition-colors hover:border-line hover:text-ink"
           >
-            Resume
+            <FiSearch size={14} />
+            <span className="hidden font-mono text-[11px] sm:inline">⌘K</span>
+          </button>
+
+          <ThemeToggle />
+
+          <a
+            href="Langlois_Resume.pdf"
+            download
+            className="ml-1 hidden rounded-md border border-line px-3.5 py-1.5 font-mono text-[12px] uppercase tracking-label text-ink transition-colors duration-200 hover:bg-surface-2 sm:block"
+          >
+            Résumé
           </a>
+
+          <button
+            onClick={() => setOpen((v) => !v)}
+            className="ml-1 grid h-9 w-9 place-items-center rounded-md text-body transition-colors hover:bg-surface-2 md:hidden"
+            aria-label={open ? 'Close menu' : 'Open menu'}
+            aria-expanded={open}
+          >
+            {open ? <FiX size={18} /> : <FiMenu size={18} />}
+          </button>
         </div>
       </div>
-    </nav>
-  );
-};
 
-export default Navbar;
+      {/* Mobile dropdown */}
+      <div
+        className={`overflow-hidden border-t border-hairline bg-canvas/95 backdrop-blur-md transition-[max-height,opacity] duration-300 ease-out md:hidden ${
+          open ? 'max-h-72 opacity-100' : 'max-h-0 opacity-0'
+        }`}
+      >
+        <ul className="mx-auto max-w-content px-6 py-2">
+          {navItems.map((item) => (
+            <li key={item.label}>
+              <button
+                onClick={() => handleNav(item.target)}
+                className="w-full border-b border-hairline py-3 text-left font-mono text-[13px] uppercase tracking-label text-body transition-colors hover:text-ink"
+              >
+                {item.label}
+              </button>
+            </li>
+          ))}
+          <li>
+            <a
+              href="Langlois_Resume.pdf"
+              download
+              onClick={() => setOpen(false)}
+              className="block py-3 text-left font-mono text-[13px] uppercase tracking-label text-body transition-colors hover:text-ink"
+            >
+              Résumé
+            </a>
+          </li>
+        </ul>
+      </div>
+    </nav>
+  )
+}
+
+export default Navbar

--- a/frontend/src/components/Projects.tsx
+++ b/frontend/src/components/Projects.tsx
@@ -1,137 +1,79 @@
-import { useRef } from 'react';
-import projects from '../extra/projects.js';
-import { ProjectData } from '../extra/projects.js';
-import { FiGithub, FiExternalLink, FiChevronLeft, FiChevronRight } from 'react-icons/fi';
+import { FiArrowUpRight, FiGithub } from 'react-icons/fi'
+import projects, { ProjectData } from '../extra/projects'
+import { Section, Reveal, Chip } from './primitives'
 
 const Projects = () => {
-    const scrollRef = useRef<HTMLDivElement>(null);
-
-    const scroll = (direction: 'left' | 'right') => {
-      if (scrollRef.current) {
-        const { scrollLeft, scrollWidth, clientWidth } = scrollRef.current;
-        
-        // Define how much to scroll (one full view)
-        const scrollAmount = clientWidth;
-
-        if (direction === 'left') {
-          // If at the very start, jump to the very end
-          if (scrollLeft <= 0) {
-            scrollRef.current.scrollTo({ left: scrollWidth, behavior: 'smooth' });
-          } else {
-            scrollRef.current.scrollBy({ left: -scrollAmount, behavior: 'smooth' });
-          }
-        } else {
-          // If at the very end (allowing for 1px rounding error), jump to the start
-          if (scrollLeft + clientWidth >= scrollWidth - 1) {
-            scrollRef.current.scrollTo({ left: 0, behavior: 'smooth' });
-          } else {
-            scrollRef.current.scrollBy({ left: scrollAmount, behavior: 'smooth' });
-          }
-        }
+  return (
+    <Section
+      id="work"
+      index="03"
+      title="Selected work"
+      action={
+        <a
+          href="https://github.com/23langloisj"
+          target="_blank"
+          rel="noreferrer"
+          className="link-sweep inline-flex items-center gap-1 font-mono text-[12px] text-link transition-colors hover:text-link-hover"
+        >
+          GitHub <FiArrowUpRight size={13} />
+        </a>
       }
-    };
+    >
+      <div className="flex flex-col gap-4">
+        {projects.map((project: ProjectData, i) => {
+          const href = project.live ?? project.code ?? undefined
+          return (
+            <Reveal key={project.title} delay={Math.min(i * 60, 180)}>
+              <a
+                href={href}
+                target="_blank"
+                rel="noreferrer"
+                className="group block overflow-hidden rounded-lg border border-hairline bg-surface transition-[transform,box-shadow,border-color] duration-300 ease-out hover:-translate-y-0.5 hover:border-line hover:shadow-card"
+              >
+                <div className="flex flex-col sm:flex-row">
+                  <div className="shrink-0 overflow-hidden border-b border-hairline bg-surface-2 sm:w-[210px] sm:border-b-0 sm:border-r">
+                    {project.image ? (
+                      <img
+                        src={project.image}
+                        alt={project.title}
+                        className="h-44 w-full object-cover grayscale-[30%] transition duration-500 ease-out group-hover:grayscale-0 sm:h-full"
+                      />
+                    ) : (
+                      <div className="grid h-44 w-full place-items-center text-line sm:h-full">
+                        <FiGithub size={32} />
+                      </div>
+                    )}
+                  </div>
 
-    return (
-        <section id="projects" className="py-20 px-6 max-w-6xl mx-auto">
-            {/* Header section remains the same */}
-            <div className="flex items-center justify-between mb-12">
-                <div className="flex items-center flex-1">
-                    <h2 className="text-3xl md:text-4xl font-bold text-slate-100 whitespace-nowrap">
-                        <span className="font-mono text-teal-400 text-2xl mr-2">03.</span>
-                        Projects
-                    </h2>
-                    <div className="h-[1px] bg-slate-700 w-full ml-6 mr-6"></div>
-                </div>
-
-                <div className="flex gap-2">
-                    <button 
-                        onClick={() => scroll('left')}
-                        className="p-2 rounded-full border border-slate-700 text-slate-400 hover:border-teal-400 hover:text-teal-400 transition-all active:scale-95"
-                    >
-                        <FiChevronLeft size={24} />
-                    </button>
-                    <button 
-                        onClick={() => scroll('right')}
-                        className="p-2 rounded-full border border-slate-700 text-slate-400 hover:border-teal-400 hover:text-teal-400 transition-all active:scale-95"
-                    >
-                        <FiChevronRight size={24} />
-                    </button>
-                </div>
-            </div>
-
-            {/* Scrollable Container */}
-            <div 
-                ref={scrollRef}
-                className="flex gap-6 overflow-x-auto snap-x snap-mandatory no-scrollbar pb-8"
-            >
-                {projects.map((project: ProjectData, index) => (
-                    <div
-                        key={index}
-                        className="snap-center shrink-0 w-full md:w-[calc(50%-12px)] lg:w-[calc(33.333%-16px)] group bg-slate-800/40 border border-slate-700 rounded-2xl overflow-hidden flex flex-col transition-all duration-300 hover:border-teal-400/50 hover:-translate-y-1"
-                    >
-                        {/* 1. Project Image Container */}
-                        <div className="relative h-48 w-full overflow-hidden bg-slate-900">
-                            {project.image ? (
-                                <img 
-                                    src={project.image} 
-                                    alt={project.title}
-                                    className="w-full h-full object-cover opacity-80 group-hover:opacity-100 group-hover:scale-105 transition-all duration-500"
-                                />
-                            ) : (
-                                <div className="w-full h-full flex items-center justify-center text-slate-700">
-                                    <FiGithub size={40} />
-                                </div>
-                            )}
-                            {/* Dark overlay for text readability if needed */}
-                            <div className="absolute inset-0 bg-gradient-to-t from-slate-900/60 to-transparent"></div>
-                            
-                            {/* Quick Links Overlayed on Image */}
-                            <div className="absolute top-4 right-4 flex gap-3">
-                                {project.code && (
-                                    <a href={project.code} target="_blank" className="p-2 bg-slate-900/80 backdrop-blur-md rounded-full text-white hover:text-teal-400 transition-colors">
-                                        <FiGithub size={18} />
-                                    </a>
-                                )}
-                                {project.live && (
-                                    <a href={project.live} target="_blank" className="p-2 bg-slate-900/80 backdrop-blur-md rounded-full text-white hover:text-teal-400 transition-colors">
-                                        <FiExternalLink size={18} />
-                                    </a>
-                                )}
-                            </div>
-                        </div>
-
-                        {/* 2. Content Container */}
-                        <div className="p-6 flex flex-col flex-grow">
-                            <h3 className="text-xl font-bold text-slate-100 mb-2 group-hover:text-teal-400 transition-colors">
-                                {project.title}
-                            </h3>
-                            
-                            <p className="text-slate-400 text-sm leading-relaxed line-clamp-3 mb-6">
-                                {project.description}
-                            </p>
-
-                            {/* 3. Tech Stack - pushed to bottom */}
-                            <div className="mt-auto flex flex-wrap gap-2">
-                                {project.technologies.slice(0, 4).map((tech, idx) => (
-                                    <span 
-                                        key={idx} 
-                                        className="font-mono text-[10px] text-teal-400/80 bg-teal-400/10 px-2 py-1 rounded border border-teal-400/20"
-                                    >
-                                        {tech}
-                                    </span>
-                                ))}
-                                {project.technologies.length > 4 && (
-                                    <span className="text-slate-500 text-[10px] self-center">
-                                        +{project.technologies.length - 4} more
-                                    </span>
-                                )}
-                            </div>
-                        </div>
+                  <div className="flex flex-1 flex-col p-5">
+                    <div className="flex items-start justify-between gap-3">
+                      <h3 className="text-[16px] font-semibold text-ink transition-colors group-hover:text-link">
+                        {project.title}
+                      </h3>
+                      <FiArrowUpRight
+                        size={17}
+                        className="mt-0.5 shrink-0 text-faint transition-colors group-hover:text-link"
+                      />
                     </div>
-                ))}
-            </div>
-        </section>
-    );
-};
 
-export default Projects;
+                    <p className="mt-2 flex-1 text-[14px] leading-relaxed text-body">
+                      {project.description}
+                    </p>
+
+                    <div className="mt-4 flex flex-wrap gap-1.5">
+                      {project.technologies.map((tech) => (
+                        <Chip key={tech}>{tech}</Chip>
+                      ))}
+                    </div>
+                  </div>
+                </div>
+              </a>
+            </Reveal>
+          )
+        })}
+      </div>
+    </Section>
+  )
+}
+
+export default Projects

--- a/frontend/src/components/ScrollProgress.tsx
+++ b/frontend/src/components/ScrollProgress.tsx
@@ -1,0 +1,31 @@
+import { useEffect, useState } from 'react'
+
+const ScrollProgress = () => {
+  const [pct, setPct] = useState(0)
+
+  useEffect(() => {
+    const onScroll = () => {
+      const el = document.documentElement
+      const max = el.scrollHeight - el.clientHeight
+      setPct(max > 0 ? (el.scrollTop / max) * 100 : 0)
+    }
+    onScroll()
+    window.addEventListener('scroll', onScroll, { passive: true })
+    window.addEventListener('resize', onScroll)
+    return () => {
+      window.removeEventListener('scroll', onScroll)
+      window.removeEventListener('resize', onScroll)
+    }
+  }, [])
+
+  return (
+    <div className="fixed inset-x-0 top-0 z-[60] h-[2px]" aria-hidden="true">
+      <div
+        className="h-full bg-link"
+        style={{ width: `${pct}%`, transition: 'width 120ms linear' }}
+      />
+    </div>
+  )
+}
+
+export default ScrollProgress

--- a/frontend/src/components/Sheflang.tsx
+++ b/frontend/src/components/Sheflang.tsx
@@ -1,124 +1,64 @@
-import { useState, useRef } from "react";
-import food from "../extra/food";
-import Modal from "./LoreModal";
-import sheflang from "../assets/sheflang.png";
-import { FoodItem } from "../extra/food";
-import { FiInfo, FiChevronLeft, FiChevronRight } from 'react-icons/fi';
+import { useState } from 'react'
+import { FiArrowUpRight } from 'react-icons/fi'
+import food, { FoodItem } from '../extra/food'
+import Modal from './LoreModal'
+import { Reveal } from './primitives'
 
 const Sheflang = () => {
-  const [showModal, setShowModal] = useState(false);
-  const [loreContent, setLoreContent] = useState("");
-  const [dishName, setDishName] = useState("");
-  const scrollRef = useRef<HTMLDivElement>(null);
-
-  const handleOpenModal = (name: string, lore: string) => {
-    setLoreContent(lore); 
-    setShowModal(true);
-    setDishName(name);
-  };
-
-  const scroll = (direction: 'left' | 'right') => {
-    if (scrollRef.current) {
-      const { scrollLeft, scrollWidth, clientWidth } = scrollRef.current;
-      const scrollAmount = clientWidth;
-
-      if (direction === 'left') {
-        if (scrollLeft <= 0) {
-          scrollRef.current.scrollTo({ left: scrollWidth, behavior: 'smooth' });
-        } else {
-          scrollRef.current.scrollBy({ left: -scrollAmount, behavior: 'smooth' });
-        }
-      } else {
-        if (scrollLeft + clientWidth >= scrollWidth - 1) {
-          scrollRef.current.scrollTo({ left: 0, behavior: 'smooth' });
-        } else {
-          scrollRef.current.scrollBy({ left: scrollAmount, behavior: 'smooth' });
-        }
-      }
-    }
-  };
+  const [active, setActive] = useState<FoodItem | null>(null)
 
   return (
-    <div id="sheflang" className="h-screen flex flex-col justify-center items-center py-12 px-6 max-w-7xl mx-auto overflow-hidden bg-[#0f172a]">
-      
-      <div className="text-center mb-8 flex flex-col items-center shrink-0">
-        <div className="relative inline-block group mb-3">
-          <div className="absolute -inset-1 bg-gradient-to-r from-teal-500 to-orange-400 rounded-full blur opacity-25 group-hover:opacity-50 transition duration-1000"></div>
-          <img 
-            src={sheflang} 
-            alt="sheflang" 
-            className="relative rounded-full w-20 h-20 md:w-28 md:h-28 object-cover border-2 border-slate-700" 
-          />
+    <div id="sheflang" className="mx-auto max-w-content px-6 pb-4 pt-10 md:pt-14">
+      <Reveal>
+        <div className="mb-4 font-mono text-eyebrow uppercase tracking-label text-muted">
+          The kitchen
         </div>
-        
-        <h1 className="text-3xl md:text-5xl font-bold text-slate-100 tracking-tight">
-          Shef<span className="text-teal-400">lang</span>
+        <h1 className="text-[38px] font-semibold leading-[1.05] tracking-display text-ink md:text-[46px]">
+          Sheflang
         </h1>
-        
-        <p className="text-slate-400 mt-2 max-w-lg mx-auto font-mono text-[10px] md:text-xs uppercase tracking-[0.2em]">
-          A collection of culinary experiments and lore.
+        <p className="mt-4 max-w-[52ch] text-[16px] leading-relaxed text-body">
+          A running log of things I&rsquo;ve cooked in college &mdash; and the
+          (mostly ridiculous) lore behind each one. Tap a dish for the story.
         </p>
-        
-        <div className="flex gap-3 mt-6">
-          <button 
-            onClick={() => scroll('left')}
-            className="p-2 rounded-full border border-slate-700 text-slate-400 hover:border-teal-400 hover:text-teal-400 transition-all active:scale-90"
-          >
-            <FiChevronLeft size={20} />
-          </button>
-          <button 
-            onClick={() => scroll('right')}
-            className="p-2 rounded-full border border-slate-700 text-slate-400 hover:border-teal-400 hover:text-teal-400 transition-all active:scale-90"
-          >
-            <FiChevronRight size={20} />
-          </button>
+        <div className="mt-4 font-mono text-[11px] uppercase tracking-label text-faint">
+          {food.length} dishes · updated occasionally
         </div>
-      </div>
-      <div 
-        ref={scrollRef}
-        className="flex gap-6 w-full overflow-x-auto snap-x snap-mandatory no-scrollbar pb-6"
-      >
-        {food.map((item: FoodItem, index) => (
-          <div 
-            key={index} 
-            className="snap-center shrink-0 w-full sm:w-[calc(50%-12px)] lg:w-[calc(33.333%-16px)] group bg-slate-800/40 border border-slate-700 rounded-3xl overflow-hidden hover:border-teal-400/50 transition-all duration-300 flex flex-col"
-          >
-            <div className="relative w-full pb-[100%] overflow-hidden">
-              <img
-                src={item.image}
-                alt={item.description}
-                className="absolute inset-0 w-full h-full object-cover grayscale-[20%] group-hover:grayscale-0 group-hover:scale-110 transition-all duration-700"
-              />
-              <div className="absolute inset-0 bg-gradient-to-t from-slate-900/90 via-transparent to-transparent"></div>
-              
-              <div className="absolute bottom-4 left-4 right-4 text-center">
-                <h3 className="text-slate-100 text-base md:text-lg font-bold tracking-tight">
-                  {item.description}
+      </Reveal>
+
+      <div className="mt-9 grid grid-cols-1 gap-4 sm:grid-cols-2">
+        {food.map((item: FoodItem, i) => (
+          <Reveal key={i} delay={Math.min(i * 30, 180)}>
+            <div className="group flex h-full flex-col overflow-hidden rounded-lg border border-hairline bg-surface transition-[transform,box-shadow,border-color] duration-300 ease-out hover:-translate-y-0.5 hover:border-line hover:shadow-card">
+              <div className="aspect-square overflow-hidden bg-surface-2">
+                <img
+                  src={item.image}
+                  alt={item.description}
+                  loading="lazy"
+                  className="h-full w-full object-cover grayscale-[15%] transition duration-500 ease-out group-hover:scale-[1.03] group-hover:grayscale-0"
+                />
+              </div>
+              <div className="flex flex-1 flex-col p-4">
+                <h3 className="text-[15px] font-semibold text-ink">
+                  {item.name}
                 </h3>
+                <p className="mt-1 line-clamp-2 flex-1 text-[13px] leading-relaxed text-body">
+                  {item.description}
+                </p>
+                <button
+                  onClick={() => setActive(item)}
+                  className="mt-3 inline-flex items-center gap-1 self-start font-mono text-[11px] uppercase tracking-label text-link transition-colors hover:text-link-hover"
+                >
+                  Read the lore <FiArrowUpRight size={12} />
+                </button>
               </div>
             </div>
-
-            <div className="p-3">
-              <button
-                onClick={() => handleOpenModal(item.name, item.lore)}
-                className="flex items-center justify-center gap-2 w-full py-2.5 rounded-2xl bg-teal-500/5 border border-teal-500/20 text-teal-400 font-mono text-[10px] uppercase tracking-widest hover:bg-teal-400/10 transition-all duration-300"
-              >
-                <FiInfo size={12} />
-                Explore Lore
-              </button>
-            </div>
-          </div>
+          </Reveal>
         ))}
       </div>
 
-      <Modal
-        showModal={showModal}
-        setShowModal={setShowModal}
-        lore={loreContent}
-        name={dishName}
-      />
+      <Modal item={active} onClose={() => setActive(null)} />
     </div>
-  );
-};
+  )
+}
 
-export default Sheflang;
+export default Sheflang

--- a/frontend/src/components/Signals.tsx
+++ b/frontend/src/components/Signals.tsx
@@ -1,0 +1,258 @@
+import { useEffect, useState, ReactNode } from 'react'
+import { Section, Reveal } from './primitives'
+import { useCountUp } from '../lib/useCountUp'
+
+const USER = '23langloisj'
+
+interface Day {
+  date: string
+  count: number
+  level: number
+}
+interface GhData {
+  repos: number
+  stars: number
+  followers: number
+  topLang: string
+  contribTotal: number
+  days: Day[]
+}
+
+const cellBg = (level: number) =>
+  level === 0
+    ? { backgroundColor: 'rgb(var(--surface-2))' }
+    : {
+        backgroundColor: `rgb(var(--signal) / ${
+          [0, 0.28, 0.5, 0.72, 1][level] ?? 1
+        })`,
+      }
+
+const Tile = ({
+  label,
+  value,
+  text,
+}: {
+  label: string
+  value?: number
+  text?: string
+}) => {
+  const n = useCountUp(value ?? 0, value != null)
+  return (
+    <div className="px-4 py-3.5">
+      <div className="font-mono text-[10px] uppercase tracking-label text-muted">
+        {label}
+      </div>
+      <div className="tnum mt-1.5 truncate text-[22px] font-semibold leading-none text-ink">
+        {text ?? n.toLocaleString('en-US')}
+      </div>
+    </div>
+  )
+}
+
+const Panel = ({ children }: { children: ReactNode }) => (
+  <div className="overflow-hidden rounded-lg border border-hairline bg-surface shadow-panel">
+    {children}
+  </div>
+)
+
+const Header = ({ live }: { live: boolean }) => (
+  <div className="flex items-center justify-between border-b border-hairline px-4 py-2.5">
+    <div className="flex items-center gap-2.5">
+      <span className="relative flex h-[7px] w-[7px]">
+        {live && (
+          <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-signal/60" />
+        )}
+        <span
+          className={`relative inline-flex h-[7px] w-[7px] rounded-full ${
+            live ? 'bg-signal' : 'bg-poppy'
+          }`}
+        />
+      </span>
+      <span className="font-mono text-[10px] font-semibold uppercase tracking-label text-muted">
+        {live ? 'LIVE' : 'OFFLINE'}
+      </span>
+      <span className="font-mono text-[11px] text-body">GitHub</span>
+    </div>
+    <span className="font-mono text-[10px] uppercase tracking-label text-faint">
+      api.github.com
+    </span>
+  </div>
+)
+
+const Signals = () => {
+  const [data, setData] = useState<GhData | null>(null)
+  const [status, setStatus] = useState<'loading' | 'ok' | 'error'>('loading')
+
+  useEffect(() => {
+    let alive = true
+
+    const load = async () => {
+      try {
+        const [profileRes, reposRes] = await Promise.all([
+          fetch(`https://api.github.com/users/${USER}`),
+          fetch(`https://api.github.com/users/${USER}/repos?per_page=100&sort=pushed`),
+        ])
+        if (!profileRes.ok || !reposRes.ok) throw new Error('gh')
+        const profile = await profileRes.json()
+        const repos: any[] = await reposRes.json()
+
+        const stars = repos.reduce((s, r) => s + (r.stargazers_count || 0), 0)
+        const langCount: Record<string, number> = {}
+        repos.forEach((r) => {
+          if (r.language && !r.fork)
+            langCount[r.language] = (langCount[r.language] || 0) + 1
+        })
+        const topLang =
+          Object.entries(langCount).sort((a, b) => b[1] - a[1])[0]?.[0] ?? '—'
+
+        // Contributions (best-effort; heatmap hides if it fails)
+        let days: Day[] = []
+        let contribTotal = 0
+        try {
+          const cRes = await fetch(
+            `https://github-contributions-api.jogruber.de/v4/${USER}?y=last`,
+          )
+          if (cRes.ok) {
+            const c = await cRes.json()
+            days = c.contributions ?? []
+            contribTotal =
+              c.total?.lastYear ??
+              days.reduce((s: number, d: Day) => s + d.count, 0)
+          }
+        } catch {
+          /* heatmap optional */
+        }
+
+        if (!alive) return
+        setData({
+          repos: profile.public_repos ?? repos.length,
+          stars,
+          followers: profile.followers ?? 0,
+          topLang,
+          contribTotal,
+          days,
+        })
+        setStatus('ok')
+      } catch {
+        if (alive) setStatus('error')
+      }
+    }
+
+    load()
+    return () => {
+      alive = false
+    }
+  }, [])
+
+  // Align the heatmap so the first column starts on the correct weekday.
+  const padded: (Day | null)[] = (() => {
+    if (!data?.days.length) return []
+    const first = new Date(data.days[0].date).getDay()
+    return [...Array(first).fill(null), ...data.days]
+  })()
+
+  return (
+    <Section
+      id="signals"
+      index="04"
+      title="GitHub"
+      action={
+        <a
+          href={`https://github.com/${USER}`}
+          target="_blank"
+          rel="noreferrer"
+          className="link-sweep font-mono text-[12px] text-link transition-colors hover:text-link-hover"
+        >
+          @{USER}
+        </a>
+      }
+    >
+      <Reveal>
+        <p className="mb-6 max-w-[52ch] text-[15px] leading-relaxed text-body">
+          A second live feed to go with the Clash panel &mdash; this one&rsquo;s
+          the code. Pulled straight from the GitHub API on load.
+        </p>
+      </Reveal>
+
+      <Reveal>
+        <Panel>
+          {status === 'loading' && (
+            <>
+              <Header live={false} />
+              <div className="animate-pulse px-4 py-12 text-center font-mono text-[11px] uppercase tracking-label text-faint">
+                Fetching commits&hellip;
+              </div>
+            </>
+          )}
+
+          {status === 'error' && (
+            <>
+              <Header live={false} />
+              <div className="px-4 py-10 text-center font-mono text-[11px] uppercase tracking-label text-faint">
+                GitHub feed unavailable — rate limit or network.
+              </div>
+            </>
+          )}
+
+          {status === 'ok' && data && (
+            <>
+              <Header live />
+
+              <div className="grid grid-cols-2 divide-x divide-hairline sm:grid-cols-4">
+                <Tile label="Repos" value={data.repos} />
+                <Tile label="Stars" value={data.stars} />
+                <div className="border-t border-hairline sm:border-t-0">
+                  <Tile label="Followers" value={data.followers} />
+                </div>
+                <div className="border-t border-hairline sm:border-t-0">
+                  <Tile label="Top lang" text={data.topLang} />
+                </div>
+              </div>
+
+              {padded.length > 0 && (
+                <div className="border-t border-hairline px-4 py-4">
+                  <div className="mb-3 flex items-baseline justify-between gap-3">
+                    <span className="font-mono text-[10px] uppercase tracking-label text-muted">
+                      Contributions
+                    </span>
+                    <span className="tnum font-mono text-[11px] text-body">
+                      {data.contribTotal.toLocaleString('en-US')} in the last
+                      year
+                    </span>
+                  </div>
+
+                  <div className="overflow-x-auto no-scrollbar">
+                    <div className="grid grid-flow-col grid-rows-7 gap-[3px]">
+                      {padded.map((d, i) => (
+                        <div
+                          key={i}
+                          title={d ? `${d.date}: ${d.count}` : undefined}
+                          className="h-[9px] w-[9px] rounded-[2px]"
+                          style={d ? cellBg(d.level) : { opacity: 0 }}
+                        />
+                      ))}
+                    </div>
+                  </div>
+
+                  <div className="mt-3 flex items-center justify-end gap-1.5 font-mono text-[10px] text-faint">
+                    <span>Less</span>
+                    {[0, 1, 2, 3, 4].map((l) => (
+                      <span
+                        key={l}
+                        className="h-[9px] w-[9px] rounded-[2px]"
+                        style={cellBg(l)}
+                      />
+                    ))}
+                    <span>More</span>
+                  </div>
+                </div>
+              )}
+            </>
+          )}
+        </Panel>
+      </Reveal>
+    </Section>
+  )
+}
+
+export default Signals

--- a/frontend/src/components/primitives.tsx
+++ b/frontend/src/components/primitives.tsx
@@ -1,0 +1,87 @@
+import { ReactNode } from 'react'
+import { useReveal } from '../lib/useReveal'
+
+/* ── Reveal: wraps content in a subtle scroll-in transition ── */
+export function Reveal({
+  children,
+  delay = 0,
+  className = '',
+}: {
+  children: ReactNode
+  delay?: number
+  className?: string
+}) {
+  const ref = useReveal<HTMLDivElement>(delay)
+  return (
+    <div ref={ref} className={`reveal ${className}`}>
+      {children}
+    </div>
+  )
+}
+
+/* ── Eyebrow: the mono uppercase label used everywhere ── */
+export function Eyebrow({
+  children,
+  className = '',
+}: {
+  children: ReactNode
+  className?: string
+}) {
+  return (
+    <span
+      className={`font-mono text-eyebrow uppercase tracking-label text-muted ${className}`}
+    >
+      {children}
+    </span>
+  )
+}
+
+/* ── Section: the one centered 660px column + section rhythm ── */
+export function Section({
+  id,
+  index,
+  title,
+  action,
+  children,
+  className = '',
+}: {
+  id?: string
+  index?: string
+  title?: string
+  action?: ReactNode
+  children: ReactNode
+  className?: string
+}) {
+  return (
+    <section
+      id={id}
+      className={`mx-auto max-w-content px-6 pt-[72px] md:pt-[88px] scroll-mt-24 ${className}`}
+    >
+      {(title || index) && (
+        <Reveal>
+          <div className="mb-7 flex items-baseline justify-between gap-4">
+            <div className="flex items-baseline gap-3">
+              {index && <Eyebrow>{index}</Eyebrow>}
+              {title && (
+                <h2 className="text-[15px] font-semibold tracking-heading text-ink">
+                  {title}
+                </h2>
+              )}
+            </div>
+            {action}
+          </div>
+        </Reveal>
+      )}
+      {children}
+    </section>
+  )
+}
+
+/* ── Chip: mono meta tag (tech stack, etc.) ── */
+export function Chip({ children }: { children: ReactNode }) {
+  return (
+    <span className="rounded-sm bg-surface-2 px-2 py-1 font-mono text-[11px] leading-none text-muted">
+      {children}
+    </span>
+  )
+}

--- a/frontend/src/extra/experiences.ts
+++ b/frontend/src/extra/experiences.ts
@@ -1,73 +1,81 @@
-import afterflea from '../assets/afterflea.png';
-import ornl from '../assets/ornl.png';
-import cmu from '../assets/cmu.png';
-import khoury from '../assets/khoury.jpeg';
-import sandbox from '../assets/sandbox.png'
-import smartleaf from '../assets/smartleaf.jpeg';
-import emoney from '../assets/emoney.png';
-
 export interface ExperienceData {
-    company: string;
-    role: string;
-    description: string;
-    live: string | null;
-    image: string;
-    date: string;
+  company: string
+  role: string
+  mark: string // monogram tile
+  date: string
+  domain: string // one-word context tag
+  summary: string // one concrete line
 }
 
-const experiences: ExperienceData[]= [
-    {
-        company: "eMoney Advisors",
-        role: "Software Engineer Co-op",
-        description: "",
-        live: null,
-        image: emoney,
-        date: "Jan 2026 - Present"
-    },
-    {
-        company: "Smartleaf",
-        role: "Software Engineer Co-op",
-        description: "",
-        live: null,
-        image: smartleaf,
-        date: "Jan 2025 - June 2025"
-    },
-    {
-        company: "Khoury College of Computer Sciences",
-        role: "DS3000 - Teaching Assistant",
-        description: "",
-        live: null,
-        image: khoury,
-        date: "Aug 2024 - Dec 2024"
-    },
-
-    {
-        company: "Sandbox @ Northeastern",
-        role: "Software Developer",
-        description: "",
-        live: null,
-        image: sandbox,
-        date: "Aug 2024 - Present"
-    },
-
-    {
-        company: "Software Engineering Institute - CMU",
-        role: "Software Developer Intern",
-        description: "",
-        live: null,
-        image: cmu,
-        date: "May 2024 - Aug 2024"
-    },
-
-    {
-        company: "Oak Ridge National Laboratory",
-        role: "Robotics Intern",
-        description: "",
-        live: null,
-        image: ornl,
-        date: "Jul 2022 - Aug 2022"
-
-    },
-];
+const experiences: ExperienceData[] = [
+  {
+    company: 'Klaviyo',
+    role: 'Software Engineer Co-op',
+    mark: 'KL',
+    date: 'Jul 2026 — Present',
+    domain: 'Martech',
+    summary: 'Building on KSocial, the social side of Klaviyo’s marketing platform.',
+  },
+  {
+    company: 'fore.tv',
+    role: 'Software Engineer',
+    mark: 'FT',
+    date: 'Mar 2026 — Present',
+    domain: 'Media',
+    summary:
+      'Part-time engineer on a live-streaming golf media platform (5,300+ viewers in month one).',
+  },
+  {
+    company: 'eMoney Advisor',
+    role: 'Software Engineer Co-op',
+    mark: 'EM',
+    date: 'Jan 2026 — Jun 2026',
+    domain: 'Fintech',
+    summary: 'Shipped features for financial-planning software used by advisors.',
+  },
+  {
+    company: 'Smartleaf',
+    role: 'Software Engineer Co-op',
+    mark: 'SL',
+    date: 'Jan 2025 — Jun 2025',
+    domain: 'Fintech',
+    summary:
+      'Built core Advisor Portal features for the automated portfolio-rebalancing platform.',
+  },
+  {
+    company: 'Sandbox @ Northeastern',
+    role: 'Technical Lead & Head of DevOps',
+    mark: 'SB',
+    date: 'Aug 2024 — Present',
+    domain: 'Platform',
+    summary:
+      'Lead student platforms and own infrastructure at Northeastern’s student-run software consultancy.',
+  },
+  {
+    company: 'Khoury College of Computer Sciences',
+    role: 'Teaching Assistant — DS 3000',
+    mark: 'TA',
+    date: 'Aug 2024 — Dec 2024',
+    domain: 'Teaching',
+    summary: 'TA’d Foundations of Data Science: office hours, grading, and support.',
+  },
+  {
+    company: 'Software Engineering Institute — CMU',
+    role: 'Software Engineer Intern',
+    mark: 'SEI',
+    date: 'May 2024 — Aug 2024',
+    domain: 'Security',
+    summary:
+      'Built GHOSTS Lite to cheaply simulate realistic network activity for cyber training.',
+  },
+  {
+    company: 'Oak Ridge National Laboratory',
+    role: 'Robotics Intern',
+    mark: 'OR',
+    date: 'Jul 2022 — Aug 2022',
+    domain: 'Robotics',
+    summary: 'Summer robotics research at a U.S. Department of Energy national lab.',
+  },
+]
 
 export default experiences

--- a/frontend/src/extra/projects.ts
+++ b/frontend/src/extra/projects.ts
@@ -1,43 +1,44 @@
-import peaceofmind from '../assets/peaceofmind.png';
-import ghosts from '../assets/ghosts.png';
-import neurojump from '../assets/neurojump.png';
+import peaceofmind from '../assets/peaceofmind.png'
+import ghosts from '../assets/ghosts.png'
+import neurojump from '../assets/neurojump.png'
 
 export interface ProjectData {
-    image: string;
-    title: string;
-    description: string;
-    live: string | null;
-    code: string | null;
-    technologies: string[];
+  image: string
+  title: string
+  description: string
+  live: string | null
+  code: string | null
+  technologies: string[]
 }
 
-const projects = [
-    {
-        image: peaceofmind,
-        title: "Peace of Mind",
-        description: "Peace of Mind is a mental health AI chatbot tailored to help college students.",
-        live: null,
-        code: "https://github.com/Oasis-NEU/f23-group23",
-        technologies: ["TypeScript", "ReactJS", "Firebase", "Python", "Flask", "NextJS", "TailwindCSS"],
-    },
+const projects: ProjectData[] = [
+  {
+    image: peaceofmind,
+    title: 'Peace of Mind',
+    description:
+      'A mental-health AI chatbot built for college students — a Next.js front end over a Python/Flask backend with Firebase auth and storage.',
+    live: null,
+    code: 'https://github.com/Oasis-NEU/f23-group23',
+    technologies: ['TypeScript', 'Next.js', 'React', 'Python', 'Flask', 'Firebase'],
+  },
+  {
+    image: ghosts,
+    title: 'GHOSTS Lite',
+    description:
+      'A lightweight rewrite of the GHOSTS framework that cheaply simulates realistic network activity for cyber-training environments. Built at the SEI.',
+    live: null,
+    code: 'https://github.com/23langloisj/GHOSTS/tree/master/src/Ghosts.Client.Lite',
+    technologies: ['.NET', 'C#'],
+  },
+  {
+    image: neurojump,
+    title: 'NeuroJump',
+    description:
+      'A jumping game whose AI teaches itself to play using NEAT neuroevolution — genomes mutate and compete until they clear every obstacle.',
+    live: null,
+    code: 'https://github.com/23langloisj/NeuroJump',
+    technologies: ['Python', 'Pygame', 'NEAT'],
+  },
+]
 
-    {
-        image: ghosts,
-        title: "GHOSTS LITE",
-        description: "GHOSTS LITE is a streamlined version of the GHOSTS framework designed to cheaply simulate realistic network activity",
-        live: null,
-        code: "https://github.com/23langloisj/GHOSTS/tree/master/src/Ghosts.Client.Lite",
-        technologies: [".NET", "C#"],
-    },
-
-    {
-        image: neurojump,
-        title: "NeuroJump",
-        description: "NeuroJump is a simple machine learning-based jumping game developed using Pygame and NeuroEvolution of Augmenting Topologies",
-        live: null,
-        code: "https://github.com/23langloisj/NeuroJump",
-        technologies: ["Python", "Pygame", "NEAT-Python"]
-    },
-];
-
-export default projects;
+export default projects

--- a/frontend/src/lib/theme.tsx
+++ b/frontend/src/lib/theme.tsx
@@ -1,0 +1,81 @@
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useState,
+  ReactNode,
+} from 'react'
+import { FiMoon, FiSun } from 'react-icons/fi'
+
+type Theme = 'light' | 'dark'
+
+interface ThemeCtx {
+  theme: Theme
+  toggle: () => void
+  setTheme: (t: Theme) => void
+}
+
+const Ctx = createContext<ThemeCtx>({
+  theme: 'light',
+  toggle: () => {},
+  setTheme: () => {},
+})
+
+/** Read the theme the anti-FOUC script already applied to <html>. */
+const initialTheme = (): Theme =>
+  typeof document !== 'undefined' &&
+  document.documentElement.classList.contains('dark')
+    ? 'dark'
+    : 'light'
+
+export function ThemeProvider({ children }: { children: ReactNode }) {
+  const [theme, setThemeState] = useState<Theme>(initialTheme)
+
+  useEffect(() => {
+    document.documentElement.classList.toggle('dark', theme === 'dark')
+    try {
+      localStorage.setItem('theme', theme)
+    } catch {
+      /* ignore */
+    }
+  }, [theme])
+
+  const setTheme = useCallback((t: Theme) => setThemeState(t), [])
+  const toggle = useCallback(
+    () => setThemeState((t) => (t === 'dark' ? 'light' : 'dark')),
+    [],
+  )
+
+  return <Ctx.Provider value={{ theme, toggle, setTheme }}>{children}</Ctx.Provider>
+}
+
+export const useTheme = () => useContext(Ctx)
+
+/** Sun/moon toggle used in the nav. */
+export function ThemeToggle({ className = '' }: { className?: string }) {
+  const { theme, toggle } = useTheme()
+  const isDark = theme === 'dark'
+  return (
+    <button
+      onClick={toggle}
+      aria-label={isDark ? 'Switch to light theme' : 'Switch to dark theme'}
+      className={`grid h-9 w-9 place-items-center rounded-md text-muted transition-colors hover:bg-surface-2 hover:text-ink ${className}`}
+    >
+      <span className="relative block h-[18px] w-[18px]">
+        <FiSun
+          size={18}
+          className={`absolute inset-0 transition-all duration-300 ease-out ${
+            isDark ? 'rotate-0 scale-100 opacity-100' : '-rotate-90 scale-0 opacity-0'
+          }`}
+        />
+        <FiMoon
+          size={18}
+          className={`absolute inset-0 transition-all duration-300 ease-out ${
+            isDark ? 'rotate-90 scale-0 opacity-0' : 'rotate-0 scale-100 opacity-100'
+          }`}
+        />
+      </span>
+    </button>
+  )
+}

--- a/frontend/src/lib/useCountUp.ts
+++ b/frontend/src/lib/useCountUp.ts
@@ -1,0 +1,34 @@
+import { useEffect, useState } from 'react'
+
+const prefersReduced = () =>
+  typeof window !== 'undefined' &&
+  window.matchMedia?.('(prefers-reduced-motion: reduce)').matches
+
+/**
+ * Animates 0 → target with an ease-out curve once `active` becomes true.
+ * Respects reduced-motion (snaps to the final value).
+ */
+export function useCountUp(target: number, active: boolean, duration = 900) {
+  const [value, setValue] = useState(0)
+
+  useEffect(() => {
+    if (!active) return
+    if (prefersReduced() || duration <= 0) {
+      setValue(target)
+      return
+    }
+
+    let raf = 0
+    const start = performance.now()
+    const tick = (now: number) => {
+      const t = Math.min(1, (now - start) / duration)
+      const eased = 1 - Math.pow(1 - t, 3) // easeOutCubic
+      setValue(Math.round(target * eased))
+      if (t < 1) raf = requestAnimationFrame(tick)
+    }
+    raf = requestAnimationFrame(tick)
+    return () => cancelAnimationFrame(raf)
+  }, [target, active, duration])
+
+  return value
+}

--- a/frontend/src/lib/useMagnetic.ts
+++ b/frontend/src/lib/useMagnetic.ts
@@ -1,0 +1,40 @@
+import { useEffect, useRef } from 'react'
+
+/**
+ * Gentle magnetic pull toward the cursor on hover. Pointer devices only;
+ * no-ops on touch and respects reduced-motion.
+ */
+export function useMagnetic<T extends HTMLElement = HTMLButtonElement>(
+  strength = 0.28,
+) {
+  const ref = useRef<T>(null)
+
+  useEffect(() => {
+    const el = ref.current
+    if (!el) return
+    if (
+      window.matchMedia('(hover: none)').matches ||
+      window.matchMedia('(prefers-reduced-motion: reduce)').matches
+    )
+      return
+
+    const onMove = (e: MouseEvent) => {
+      const r = el.getBoundingClientRect()
+      const x = e.clientX - (r.left + r.width / 2)
+      const y = e.clientY - (r.top + r.height / 2)
+      el.style.transform = `translate(${x * strength}px, ${y * strength}px)`
+    }
+    const onLeave = () => {
+      el.style.transform = ''
+    }
+
+    el.addEventListener('mousemove', onMove)
+    el.addEventListener('mouseleave', onLeave)
+    return () => {
+      el.removeEventListener('mousemove', onMove)
+      el.removeEventListener('mouseleave', onLeave)
+    }
+  }, [strength])
+
+  return ref
+}

--- a/frontend/src/lib/useReveal.ts
+++ b/frontend/src/lib/useReveal.ts
@@ -1,0 +1,56 @@
+import { useEffect, useRef } from 'react'
+
+/**
+ * Adds `.is-visible` the first time an element is in view.
+ *
+ * Robustness first: anything already on screen at mount reveals immediately
+ * (no dependency on IntersectionObserver timing), below-the-fold elements
+ * reveal as they scroll in, and a failsafe guarantees content is never left
+ * hidden even if IntersectionObserver never fires.
+ */
+export function useReveal<T extends HTMLElement = HTMLDivElement>(delay = 0) {
+  const ref = useRef<T>(null)
+
+  useEffect(() => {
+    const el = ref.current
+    if (!el) return
+
+    const show = () => {
+      if (delay) el.style.transitionDelay = `${delay}ms`
+      el.classList.add('is-visible')
+    }
+
+    // Already in view (e.g. above the fold on load) → reveal right away.
+    const rect = el.getBoundingClientRect()
+    const inView = rect.top < window.innerHeight && rect.bottom > 0
+    if (inView || typeof IntersectionObserver === 'undefined') {
+      show()
+      return
+    }
+
+    const io = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting) {
+          show()
+          io.disconnect()
+          clearTimeout(failsafe)
+        }
+      },
+      { threshold: 0.12, rootMargin: '0px 0px -8% 0px' },
+    )
+    io.observe(el)
+
+    // Never leave content invisible if the observer never fires.
+    const failsafe = window.setTimeout(() => {
+      show()
+      io.disconnect()
+    }, 2500)
+
+    return () => {
+      io.disconnect()
+      clearTimeout(failsafe)
+    }
+  }, [delay])
+
+  return ref
+}

--- a/frontend/src/lib/useSiteNav.ts
+++ b/frontend/src/lib/useSiteNav.ts
@@ -1,0 +1,52 @@
+import { useCallback } from 'react'
+import { useNavigate, useLocation } from 'react-router-dom'
+
+export interface SectionLink {
+  label: string
+  target: string // element id, or a path starting with "/"
+}
+
+export const SECTIONS: SectionLink[] = [
+  { label: 'About', target: 'about' },
+  { label: 'Experience', target: 'experience' },
+  { label: 'Work', target: 'work' },
+  { label: 'Signals', target: 'signals' },
+  { label: 'Contact', target: 'contact' },
+]
+
+export const EXTERNAL = {
+  github: 'https://github.com/23langloisj',
+  linkedin: 'https://www.linkedin.com/in/jacob-langlois/',
+  instagram: 'https://www.instagram.com/jake.langlois1/',
+  email: 'mailto:langlois.j@northeastern.edu',
+  resume: 'Langlois_Resume.pdf',
+}
+
+/** Shared navigation used by the navbar, command palette, and hero. */
+export function useSiteNav() {
+  const navigate = useNavigate()
+  const { pathname } = useLocation()
+
+  const scrollToId = useCallback((id: string) => {
+    document.getElementById(id)?.scrollIntoView({ behavior: 'smooth' })
+  }, [])
+
+  const go = useCallback(
+    (target: string) => {
+      if (target.startsWith('/')) {
+        navigate(target)
+        window.scrollTo(0, 0)
+        return
+      }
+      if (pathname !== '/') {
+        navigate('/')
+        window.setTimeout(() => scrollToId(target), 90)
+      } else {
+        scrollToId(target)
+      }
+    },
+    [navigate, pathname, scrollToId],
+  )
+
+  return { go, scrollToId, pathname }
+}

--- a/frontend/src/styles/tailwind.css
+++ b/frontend/src/styles/tailwind.css
@@ -1,106 +1,209 @@
-@import url('https://fonts.googleapis.com/css2?family=Inter:wght@300;400;600;700&family=Fira+Code:wght@400;600&display=swap');
-
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
 
-/* Body */
-body {
-  font-family: 'Inter', sans-serif; 
-  background-color: #0f172a; 
-  color: #e2e8f0;
+@layer base {
+  /* ── Light theme (default) ── */
+  :root {
+    --canvas: 249 250 251;
+    --surface: 255 255 255;
+    --surface-2: 243 246 247;
+    --ink: 29 30 32;
+    --body: 75 77 78;
+    --muted: 116 117 118;
+    --faint: 172 176 180;
+    --hairline: 234 237 239;
+    --line: 196 201 207;
+    --link: 21 95 234;
+    --link-hover: 5 51 158;
+    --signal: 44 181 107;
+    --poppy: 249 99 83;
+    --inverse-bg: 29 30 32;
+    --inverse-fg: 255 255 255;
+    --shadow: 29 30 32;
+    color-scheme: light;
+  }
+
+  /* ── Dark theme ── */
+  .dark {
+    --canvas: 20 20 21;
+    --surface: 29 30 32;
+    --surface-2: 42 43 45;
+    --ink: 244 246 248;
+    --body: 196 201 207;
+    --muted: 147 148 149;
+    --faint: 93 94 96;
+    --hairline: 45 46 48;
+    --line: 61 62 64;
+    --link: 107 165 255;
+    --link-hover: 160 195 255;
+    --signal: 68 217 133;
+    --poppy: 249 99 83;
+    --inverse-bg: 240 241 243;
+    --inverse-fg: 20 20 21;
+    --shadow: 0 0 0;
+    color-scheme: dark;
+  }
+
+  html {
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+    text-rendering: optimizeLegibility;
+    scroll-behavior: smooth;
+  }
+
+  body {
+    font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI',
+      Roboto, 'Helvetica Neue', Arial, sans-serif;
+    background-color: rgb(var(--canvas));
+    color: rgb(var(--body));
+  }
+
+  ::selection {
+    background: rgb(var(--link) / 0.22);
+    color: rgb(var(--ink));
+  }
+
+  :focus-visible {
+    outline: 2px solid rgb(var(--link));
+    outline-offset: 2px;
+    border-radius: 3px;
+  }
+
+  /* Smooth the light ⇄ dark swap (leaves component transforms untouched). */
+  *,
+  *::before,
+  *::after {
+    transition:
+      background-color 0.28s ease,
+      border-color 0.28s ease,
+      color 0.28s ease;
+  }
 }
 
-.font-handwriting {
-  font-family: 'Caveat', cursive;
-}
-
-.no-scrollbar::-webkit-scrollbar {
+@layer utilities {
+  .no-scrollbar::-webkit-scrollbar {
     display: none;
   }
-
-.timeline-date {
-  @apply font-bold text-xl;
-}
-
-/* Navbar */
-.hover-pointer {
-  @apply hover:cursor-pointer;
-}
-
-.nav-logo {
-  @apply text-[#c2edda] text-2xl xl:text-3xl font-bold tracking-tight;
-}
-
-.nav-item {
-  @apply text-base xl:text-xl;
-}
-
-.northeastern-color {
-  color: #e31c25;
-}
-
-.horizontal-gradient {
-  background: linear-gradient(to right, #1bd7bb, #2af598);
-  -webkit-background-clip: text;
-  color: transparent;
-}
-
-.seperator-line {
-  @apply border-t border-gray-600 pt-2 sm:pt-3;
-}
-
-@keyframes gradientAnimation {
-  0% {
-    background-position: 50% 50%;
+  .no-scrollbar {
+    -ms-overflow-style: none;
+    scrollbar-width: none;
   }
-  50% {
-    background-position: 100% 50%;
+  .tnum {
+    font-variant-numeric: tabular-nums;
+    font-feature-settings: 'tnum';
   }
-  100% {
-    background-position: 50% 50%;
+
+  /* Faint engineering dot-grid — theme aware. */
+  .bg-dotgrid {
+    background-image: radial-gradient(
+      rgb(var(--line) / 0.55) 1px,
+      transparent 1px
+    );
+    background-size: 22px 22px;
   }
 }
 
-.animation-gradient {
-  background: linear-gradient(90deg, #17d2c4, #91fff7, #4663ac, #4efff2);
-  background-size: 400% 400%;
-  animation: gradientAnimation 5s infinite;
+/* ── Cursor spotlight (hero) ── */
+.spotlight {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background: radial-gradient(
+    260px circle at var(--mx, 50%) var(--my, 0%),
+    rgb(var(--link) / 0.1),
+    transparent 70%
+  );
+  opacity: 0;
+  transition: opacity 0.4s ease;
+}
+.spotlight.is-live {
+  opacity: 1;
 }
 
-.northeastern-animation {
-  color: linear-gradient(90deg, #17d2c4, #91fff7, #2f4f4f, #4efff2);
-  animation: gradientAnimation 3s infinite;
+/* ── Reveal on scroll ── */
+.reveal {
+  opacity: 0;
+  transform: translateY(14px);
+  transition:
+    opacity 0.7s cubic-bezier(0.16, 1, 0.3, 1),
+    transform 0.7s cubic-bezier(0.16, 1, 0.3, 1);
+  will-change: opacity, transform;
+}
+.reveal.is-visible {
+  opacity: 1;
+  transform: none;
 }
 
-.color {
-  @apply hover:text-[#c2edda];
+/* ── Animated link underline sweep ── */
+.link-sweep {
+  background-image: linear-gradient(currentColor, currentColor);
+  background-size: 0% 1.5px;
+  background-position: 0 100%;
+  background-repeat: no-repeat;
+  transition: background-size 0.3s cubic-bezier(0.16, 1, 0.3, 1);
+}
+.link-sweep:hover {
+  background-size: 100% 1.5px;
 }
 
-.text-green {
-  color: #c2edda;
+/* ── cmdk command palette ── */
+[cmdk-overlay] {
+  position: fixed;
+  inset: 0;
+  z-index: 120;
+  background: rgb(0 0 0 / 0.4);
+  backdrop-filter: blur(4px);
+  animation: cmdk-fade 0.18s ease-out;
+}
+[cmdk-dialog] {
+  position: fixed;
+  inset: 0;
+  z-index: 121;
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  padding: 14vh 16px 16px;
+}
+[cmdk-group-heading] {
+  padding: 10px 8px 6px;
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  font-size: 10px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgb(var(--muted));
+}
+[cmdk-item] {
+  cursor: pointer;
+}
+[cmdk-item][data-selected='true'] {
+  background: rgb(var(--surface-2));
+}
+[cmdk-item][aria-disabled='true'] {
+  opacity: 0.4;
+}
+@keyframes cmdk-fade {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
 }
 
-.instagram-icon:hover {
-  color: #e4405f; /* Instagram's brand color */
-}
-
-.mail-icon:hover {
-  color: #0072c6; /* Outlook's mail color */
-}
-
-.instagram-color {
-  color: #e4405f;
-}
-
-.mail-color {
-  color: #0072c6;
-}
-
-.linkedin-icon:hover {
-  color: #0077b5;
-}
-
-.github-icon:hover {
-  color: #6e5494;
+@media (prefers-reduced-motion: reduce) {
+  html {
+    scroll-behavior: auto;
+  }
+  .reveal {
+    opacity: 1;
+    transform: none;
+    transition: none;
+  }
+  *,
+  *::before,
+  *::after {
+    transition-duration: 0.01ms !important;
+    animation-duration: 0.01ms !important;
+  }
 }

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -1,11 +1,78 @@
 /** @type {import('tailwindcss').Config} */
+const withVar = (v) => `rgb(var(${v}) / <alpha-value>)`
+
 export default {
-  content: ["./index.html", "./src/**/*.{tsx,ts}" ],
+  darkMode: 'class',
+  content: ['./index.html', './src/**/*.{tsx,ts}'],
   theme: {
     extend: {
-      textColor: ['hover'],
+      colors: {
+        // ── Semantic tokens (CSS vars → swap in dark mode) ──
+        canvas: withVar('--canvas'), //     page background
+        surface: withVar('--surface'), //   cards / raised surfaces
+        'surface-2': withVar('--surface-2'), // subtle raised
+        ink: withVar('--ink'), //           primary text / primary btn
+        body: withVar('--body'), //         body copy
+        muted: withVar('--muted'), //       labels, meta, dates
+        faint: withVar('--faint'), //       very subtle
+        hairline: withVar('--hairline'), // subtle 1px borders
+        line: withVar('--line'), //         default borders
+        link: withVar('--link'), //         links only
+        'link-hover': withVar('--link-hover'),
+        signal: withVar('--signal'), //     availability / live dot
+        poppy: withVar('--poppy'), //       brand accent
+        // Inverse pair — the "spotlight" panels (contact, primary buttons)
+        inverse: withVar('--inverse-bg'),
+        'inverse-fg': withVar('--inverse-fg'),
+
+        // ── Raw scales (accents, heatmap) ──
+        coolgray: {
+          95: '#F9FAFB', 100: '#F3F6F7', 200: '#EAEDEF', 300: '#C4C9CF',
+          400: '#ACB0B4', 500: '#939495', 600: '#797A7B', 625: '#747576',
+          650: '#5D5E60', 800: '#4B4D4E', 900: '#37383A', 1000: '#2A2B2D',
+          1100: '#1D1E20', 1200: '#141415', 1250: '#070708',
+        },
+        blue: { 100: '#E0F2FF', 300: '#B9DAFD', 500: '#569BF5', 700: '#155FEA', 900: '#05339E' },
+        green: { 100: '#DAFBE4', 300: '#96EDBB', 400: '#44D985', 500: '#2CB56B', 650: '#228654', 700: '#137147', 900: '#063C26' },
+      },
+      fontFamily: {
+        sans: [
+          'system-ui', '-apple-system', 'BlinkMacSystemFont', "'Segoe UI'",
+          'Roboto', "'Helvetica Neue'", 'Arial', 'sans-serif',
+        ],
+        mono: [
+          "'JetBrains Mono'", 'ui-monospace', 'Menlo', 'Monaco',
+          "'Cascadia Mono'", "'Roboto Mono'", "'Source Code Pro'", 'monospace',
+        ],
+      },
+      maxWidth: { content: '660px', wide: '720px' },
+      borderRadius: { sm: '4px', md: '8px', lg: '12px', xl: '16px', '2xl': '20px' },
+      letterSpacing: { display: '-0.025em', heading: '-0.02em', label: '0.08em' },
+      fontSize: {
+        eyebrow: ['12px', { lineHeight: '1', letterSpacing: '0.08em' }],
+        meta: ['13px', { lineHeight: '1.4' }],
+      },
+      boxShadow: {
+        card: '0 6px 24px -10px rgb(var(--shadow) / 0.16), 0 2px 6px -2px rgb(var(--shadow) / 0.08)',
+        panel: '0 1px 2px rgb(var(--shadow) / 0.06)',
+        pop: '0 20px 60px -20px rgb(var(--shadow) / 0.35)',
+      },
+      transitionTimingFunction: { out: 'cubic-bezier(0.16, 1, 0.3, 1)' },
+      keyframes: {
+        blink: { '0%,100%': { opacity: '1' }, '50%': { opacity: '0' } },
+        'grid-pan': { '0%': { backgroundPosition: '0 0' }, '100%': { backgroundPosition: '40px 40px' } },
+        'fade-in': { from: { opacity: '0' }, to: { opacity: '1' } },
+        'pop-in': {
+          from: { opacity: '0', transform: 'translateY(8px) scale(.98)' },
+          to: { opacity: '1', transform: 'none' },
+        },
+      },
+      animation: {
+        blink: 'blink 1.1s step-end infinite',
+        'fade-in': 'fade-in 0.2s ease-out',
+        'pop-in': 'pop-in 0.22s cubic-bezier(0.16,1,0.3,1)',
+      },
     },
   },
   plugins: [],
 }
-

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -6,6 +6,12 @@ import autoprefixer from 'autoprefixer'
 
 export default defineConfig({
   plugins: [react()],
+  resolve: {
+    dedupe: ['react', 'react-dom'],
+  },
+  optimizeDeps: {
+    include: ['react', 'react-dom', 'cmdk'],
+  },
   css: {
     postcss: {
       plugins: [


### PR DESCRIPTION
## Summary

Full redesign of jakelanglois.com around a calm, typographic **light/dark design system** derived from Klaviyo Ascent, plus a craft-forward interactive layer.

### Design foundation
- CSS-variable tokens → light & dark as a clean swap (inverse pair keeps the contact block / primary buttons correct in both themes)
- system-ui + JetBrains Mono · single 660px column · hairline borders · 12px radius · hover-only elevation
- Content refreshed from LinkedIn (Klaviyo + fore.tv added, dates corrected)

### Highlights
- **⌘K command palette** (cmdk) — jump to sections, open links, download résumé, switch theme
- **Light ⇄ dark theme** toggle — system-aware, persisted, no flash on load
- **Live Clash of Clans panel** — count-up stats from the Render backend, with a graceful asleep/offline state
- **GitHub "Signals" section** — live repo/star/follower stats + a contribution heatmap (client-side, no backend)
- Hero cursor spotlight + dot-grid backdrop, scroll-progress bar + scroll-spy nav, magnetic button, animated link underlines, subtle scroll reveals
- Sheflang "kitchen" page + lore modal restyled (casual voice preserved)

### Tooling
- Removed `react-scroll`, `react-vertical-timeline-component`, `axios`; added `cmdk`
- `vite resolve.dedupe` for React (fixes cmdk "Invalid hook call")
- `tsc` build clean; verified light + dark, desktop + mobile, zero console errors

## Test plan
- [ ] `cd frontend && npm run dev` → http://localhost:5173
- [ ] Toggle theme (nav button or ⌘K) in both light and dark
- [ ] Open ⌘K palette and navigate
- [ ] Clash + GitHub panels load live data
- [ ] Mobile: nav controls fit, layout responsive

🤖 Generated with [Claude Code](https://claude.com/claude-code)
